### PR TITLE
Remove uppercased workflow name, add badges

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,3 @@
-name: Rust
-
 on: [push]
 
 jobs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,3 +1,5 @@
+name: rust
+
 on: [push]
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # tower-lsp
 
+[![Build Status][s1]][gh] [![Crates.io][s2]][ci] [![Documentation][s3]][docs]
+
+[s1]: https://github.com/ebkalderon/tower-lsp/workflows/rust/badge.svg
+[gh]: https://github.com/ebkalderon/tower-lsp/actions
+[s2]: https://img.shields.io/crates/v/tower-lsp.svg
+[ci]: https://crates.io/crates/tower-lsp
+[s3]: https://img.shields.io/badge/docs-master-blue.svg
+[docs]: https://docs.rs/tower-lsp
+
 [Language Server Protocol] implementation for Rust based on [Tower].
 
 [Language Server Protocol]: https://microsoft.github.io/language-server-protocol


### PR DESCRIPTION
### Added

* Add badges for build status, crates.io, and docs.rs to `README.md`.

### Changed

* Rename GitHub workflow to lowercase.