### PR TITLE
Add more unit tests

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -133,7 +133,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn round_trip() {
+    fn encode_and_decode() {
         let decoded = r#"{"jsonrpc":"2.0","method":"exit"}"#.to_string();
         let encoded = format!("Content-Length: {}\r\n\r\n{}", decoded.len(), decoded);
 


### PR DESCRIPTION
### Added

* Add unit tests for `Printer`.
* Add exit notification unit test for `LspService`.
* Add unit tests for stdio `Server`.

### Changed

* Rename `round_trip()` unit test for codec to `encode_and_decode()`.
