### PR TITLE
Spec compliant server initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Add `ExitedError` for when calling `LspService` after it has already exited.
+
+### Changed
+
+* Language server now returns server error code `-32002` if any method is called
+  before `initialize` request is received, [as per the spec][init].
+* `LspService` sets `Service::Error` to `ExitedError`.
+* `Server` can now accept any service where `Service::Error` is convertible to
+  `Box<dyn Error + Send + Sync>`. This enables compatibility with most Tower
+  middleware.
+* Remove `'static` bounds on some `Server` and `ExitReceiver` methods.
+
+[init]: https://microsoft.github.io/language-server-protocol/specification#initialize
+
 ## [0.1.0] - 2019-09-02
 
 ### Added

--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -282,6 +282,10 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
     }
 }
 
+/// Error response returned for every request received before the server is initialized.
+///
+/// See [here](https://microsoft.github.io/language-server-protocol/specification#initialize) for
+/// reference.
 fn not_initialized_error() -> Error {
     Error::new(ErrorCode::ServerError(-32002))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@
 pub extern crate lsp_types;
 
 pub use self::delegate::{MessageStream, Printer};
-pub use self::service::{ExitReceiver, LspService};
+pub use self::service::{ExitReceiver, ExitedError, LspService};
 pub use self::stdio::Server;
 
 use futures::Future;

--- a/src/service.rs
+++ b/src/service.rs
@@ -38,9 +38,9 @@ impl ExitReceiver {
     /// Drives the future to completion, only canceling if the [`exit`] notification is received.
     ///
     /// [`exit`]: https://microsoft.github.io/language-server-protocol/specification#exit
-    pub fn run_until_exit<F>(self, future: F) -> impl Future<Item = (), Error = ()> + Send + 'static
+    pub fn run_until_exit<F>(self, future: F) -> impl Future<Item = (), Error = ()> + Send
     where
-        F: Future<Item = (), Error = ()> + Send + 'static,
+        F: Future<Item = (), Error = ()> + Send,
     {
         self.0
             .then(|_| Ok(()))

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -54,11 +54,11 @@ where
     }
 
     /// Spawns the service with messages read through `stdin` and responses printed to `stdout`.
-    pub fn serve<T>(self, service: T) -> impl Future<Item = (), Error = ()> + Send + 'static
+    pub fn serve<T>(self, service: T) -> impl Future<Item = (), Error = ()> + Send
     where
         T: Service<String, Response = String> + Send + 'static,
         T::Error: Into<Box<dyn Error + Send + Sync>>,
-        T::Future: Send + 'static,
+        T::Future: Send,
     {
         let (sender, receiver) = mpsc::channel(1);
 


### PR DESCRIPTION
### Added

* Add `initialized` boolean field for `Delegate` and `Printer`.
* Return server error if any method is called before `initialize`.
* Add `ExitedError` for when `LspService` is called after `exit` notification is received.

### Changed

* Allow spawning services in `Server` with errors convertible into `Box<dyn Error + Send + Sync>`.
* Remove `'static` bounds on some `Server` and `ExitReceiver` methods.
* Update `CHANGELOG.md`.