### PR TITLE
Fix broken doc comment link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fix broken doc link to `textDocument/didChange` in `LanguageServer` trait.
+
 ## [0.2.0] - 2019-09-03
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// [`textDocument/didOpen`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_didOpen
     fn did_open(&self, printer: &Printer, params: DidOpenTextDocumentParams);
 
-    /// The [`textDocument/didOpen`] notification is sent from the client to the server to signal
+    /// The [`textDocument/didChange`] notification is sent from the client to the server to signal
     /// changes to a text document.
     ///
     /// This notification will contain a distinct version tag and a list of edits made to the


### PR DESCRIPTION
### Fixed

* Fix broken doc link to `textDocument/didChange` in `LanguageServer` trait.