### PR TITLE
Rename highlight() methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ impl LanguageServer for Backend {
         Box::new(future::ok(None))
     }
 
-    fn highlight(&self, _: TextDocumentPositionParams) -> Self::HighlightFuture {
+    fn document_highlight(&self, _: TextDocumentPositionParams) -> Self::HighlightFuture {
         Box::new(future::ok(None))
     }
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -43,7 +43,7 @@ impl LanguageServer for Backend {
         Box::new(future::ok(None))
     }
 
-    fn highlight(&self, _: TextDocumentPositionParams) -> Self::HighlightFuture {
+    fn document_highlight(&self, _: TextDocumentPositionParams) -> Self::HighlightFuture {
         Box::new(future::ok(None))
     }
 }

--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -146,7 +146,7 @@ pub trait LanguageServerCore {
     fn hover(&self, params: Params) -> BoxFuture<Option<Hover>>;
 
     #[rpc(name = "textDocument/documentHighlight", raw_params)]
-    fn highlight(&self, params: Params) -> BoxFuture<Option<Vec<DocumentHighlight>>>;
+    fn document_highlight(&self, params: Params) -> BoxFuture<Option<Vec<DocumentHighlight>>>;
 }
 
 /// Wraps the language server backend and provides a `Printer` for sending notifications.
@@ -262,11 +262,14 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
         }
     }
 
-    fn highlight(&self, params: Params) -> BoxFuture<Option<Vec<DocumentHighlight>>> {
-        trace!("received `textDocument/highlight` request: {:?}", params);
+    fn document_highlight(&self, params: Params) -> BoxFuture<Option<Vec<DocumentHighlight>>> {
+        trace!(
+            "received `textDocument/documentHighlight` request: {:?}",
+            params
+        );
         if self.initialized.load(Ordering::SeqCst) {
             match params.parse::<TextDocumentPositionParams>() {
-                Ok(params) => Box::new(self.server.highlight(params)),
+                Ok(params) => Box::new(self.server.document_highlight(params)),
                 Err(err) => Box::new(future::err(Error::invalid_params_with_details(
                     "invalid parameters",
                     err,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@
 //!         Box::new(future::ok(None))
 //!     }
 //!
-//!     fn highlight(&self, _: TextDocumentPositionParams) -> Self::HighlightFuture {
+//!     fn document_highlight(&self, _: TextDocumentPositionParams) -> Self::HighlightFuture {
 //!         Box::new(future::ok(None))
 //!     }
 //! }
@@ -178,7 +178,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// be more fuzzy.
     ///
     /// [`textDocument/documentHighlight`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_documentHighlight
-    fn highlight(&self, params: TextDocumentPositionParams) -> Self::HighlightFuture;
+    fn document_highlight(&self, params: TextDocumentPositionParams) -> Self::HighlightFuture;
 }
 
 impl<S: ?Sized + LanguageServer> LanguageServer for Box<S> {
@@ -218,7 +218,7 @@ impl<S: ?Sized + LanguageServer> LanguageServer for Box<S> {
         (**self).hover(params)
     }
 
-    fn highlight(&self, params: TextDocumentPositionParams) -> Self::HighlightFuture {
-        (**self).highlight(params)
+    fn document_highlight(&self, params: TextDocumentPositionParams) -> Self::HighlightFuture {
+        (**self).document_highlight(params)
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -197,7 +197,7 @@ mod tests {
             Box::new(future::ok(None))
         }
 
-        fn highlight(&self, _: TextDocumentPositionParams) -> Self::HighlightFuture {
+        fn document_highlight(&self, _: TextDocumentPositionParams) -> Self::HighlightFuture {
             Box::new(future::ok(None))
         }
     }


### PR DESCRIPTION
### Changed

* Rename `highlight()` methods to `document_highlight()` to match [specification](https://microsoft.github.io/language-server-protocol/specification#textDocument_documentHighlight).