### PR TITLE
Add Incoming request type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ jsonrpc-derive = "13.1"
 log = "0.4.7"
 lsp-types = "0.60.0"
 nom = "5.0.1"
-serde = "1.0.99"
+serde = { version = "1.0.99", features = ["derive"] }
 serde_json = "1.0.40"
 tokio-codec = "0.1.1"
 tokio-executor = "0.1.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ use lsp_types::*;
 
 mod codec;
 mod delegate;
+mod message;
 mod service;
 mod stdio;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@
 pub extern crate lsp_types;
 
 pub use self::delegate::{MessageStream, Printer};
+pub use self::message::Incoming;
 pub use self::service::{ExitReceiver, ExitedError, LspService};
 pub use self::stdio::Server;
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,0 +1,57 @@
+//! Messages understood by the Language Server Protocol.
+
+use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::str::FromStr;
+
+use jsonrpc_core::types::request::{MethodCall, Notification};
+use jsonrpc_core::types::response::Output;
+use serde::{Deserialize, Serialize};
+use serde_json::Error;
+
+/// An incoming JSON-RPC message.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Incoming {
+    /// Request sent from the client to the server.
+    ///
+    /// This incoming message will produce a response.
+    Request(MethodCall),
+    /// Notification sent from the client to the server.
+    ///
+    /// This incoming message will not produce a response.
+    Notification(Notification),
+    /// Response sent from the client to the server.
+    ///
+    /// This incoming message will not produce a response.
+    Response(Output),
+    /// An unrecognized incoming message.
+    ///
+    /// This incoming message will produce a response.
+    #[serde(skip)]
+    Invalid(String),
+}
+
+impl Display for Incoming {
+    fn fmt(&self, fmt: &mut Formatter) -> FmtResult {
+        match *self {
+            Incoming::Request(ref req) => fmt.write_str(&serde_json::to_string(req).unwrap()),
+            Incoming::Notification(ref n) => fmt.write_str(&serde_json::to_string(n).unwrap()),
+            Incoming::Response(ref res) => fmt.write_str(&serde_json::to_string(res).unwrap()),
+            Incoming::Invalid(ref s) => fmt.write_str(s),
+        }
+    }
+}
+
+impl From<String> for Incoming {
+    fn from(s: String) -> Self {
+        Incoming::from_str(&s).unwrap_or_else(|_| Incoming::Invalid(s))
+    }
+}
+
+impl FromStr for Incoming {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}


### PR DESCRIPTION
### Added

* Depend on `serde_derive` by enabling the `"derive"` feature on `serde`.
* Add `Incoming` message type.

### Changed

* Change `LspService` request type to `Incoming`.
* Update `Server` to accept `T: Service<Incoming>`.
* Drop all incoming responses to requests sent from `Printer` for now. This is a short-term hack until #13 is resolved in a satisfactory manner.

---

This pull request should lay the basic groundwork for sending server-to-client requests, as described in #13. It also contains a temporary hack that allows us to send requests but never read the responses, dropping them instead. Basically, we are treating them like JSON-RPC notifications for now.

This hack is similar to what RLS does to support [client/registerCapability](https://github.com/rust-lang/rls/blob/7b0a20bf13b7061b1eb31a058117ac5517ff8cc9/rls/src/actions/notifications.rs#L44-L45), [client/unregisterCapability](https://github.com/rust-lang/rls/blob/7b0a20bf13b7061b1eb31a058117ac5517ff8cc9/rls/src/actions/notifications.rs#L222-L223), and [workspace/applyEdit](https://github.com/rust-lang/rls/blob/b06cbba70d9582e35ccfce68ed3ae37c650a988d/rls/src/actions/requests.rs#L410-L419). The first and second methods have empty response bodies, and checking the response body of the third isn't that critical for basic support.

Maybe in the future we can come up with a better solution to support server-to-client requests, but being able to distinguish between various incoming message types is a good first step in this direction.