### PR TITLE
Add capability registration, use minimum Rust 1.34.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust-version: [1.33.0, beta, nightly]
+        rust-version: [1.34.0, beta, nightly]
 
     steps:
     - uses: hecrj/setup-rust-action@master

--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -11,7 +11,7 @@ use jsonrpc_core::{BoxFuture, Error, Result as RpcResult};
 use jsonrpc_derive::rpc;
 use log::{error, trace};
 use lsp_types::notification::{LogMessage, Notification, PublishDiagnostics, ShowMessage};
-use lsp_types::request::Request;
+use lsp_types::request::{RegisterCapability, Request, UnregisterCapability};
 use lsp_types::*;
 use serde::Serialize;
 
@@ -80,6 +80,34 @@ impl Printer {
             typ,
             message: message.to_string(),
         }));
+    }
+
+    /// Register a new capability with the client.
+    ///
+    /// This corresponds to the [`client/registerCapability`] request.
+    ///
+    /// [`client/registerCapability`]: https://microsoft.github.io/language-server-protocol/specification#client_registerCapability
+    pub fn register_capability(&self, registrations: Vec<Registration>) {
+        // FIXME: Check whether the request succeeded or failed.
+        let id = self.request_id.fetch_add(1, Ordering::SeqCst);
+        self.send_message(make_request::<RegisterCapability>(
+            id,
+            RegistrationParams { registrations },
+        ))
+    }
+
+    /// Unregister a capability with the client.
+    ///
+    /// This corresponds to the [`client/unregisterCapability`] request.
+    ///
+    /// [`client/unregisterCapability`]: https://microsoft.github.io/language-server-protocol/specification#client_unregisterCapability
+    pub fn unregister_capability(&self, unregisterations: Vec<Unregistration>) {
+        // FIXME: Check whether the request succeeded or failed.
+        let id = self.request_id.fetch_add(1, Ordering::SeqCst);
+        self.send_message(make_request::<UnregisterCapability>(
+            id,
+            UnregistrationParams { unregisterations },
+        ))
     }
 
     fn send_message(&self, message: String) {

--- a/src/service.rs
+++ b/src/service.rs
@@ -9,7 +9,7 @@ use futures::future::{self, Future, Shared, SharedError, SharedItem};
 use futures::sync::oneshot::{self, Canceled};
 use futures::{Async, Poll};
 use jsonrpc_core::IoHandler;
-use log::{info, trace};
+use log::{debug, info, trace};
 use lsp_types::notification::{Exit, Notification};
 use tower_service::Service;
 
@@ -145,11 +145,12 @@ impl Service<Incoming> for LspService {
         if self.stopped.load(Ordering::SeqCst) {
             Box::new(future::err(ExitedError))
         } else {
-            if let Incoming::Response(_) = request {
+            if let Incoming::Response(r) = request {
                 // FIXME: Currently, we are dropping responses to requests created in `Printer`.
                 // We need some way to route them back to the `Printer`. See this issue for more:
                 //
                 // https://github.com/ebkalderon/tower-lsp/issues/13
+                debug!("dropping client response, as per GitHub issue #13: {:?}", r);
                 Box::new(future::ok(String::new()))
             } else {
                 Box::new(


### PR DESCRIPTION
### Added

* Add `request_id` field to `Printer`, which keeps track of the next JSON-RPC request ID.
* Add internal `make_request()` function, equivalent to the existing `make_notification()`.
* Add `register_capability()` and `unregister_capability()` methods to `Printer`.

### Changed

* Increase minimum Rust version to 1.34.0 for `AtomicU64`.
* Log dropped incoming responses for debugging purposes.

This pull request is another step toward resolving #13.