### PR TITLE
Use env_logger 0.6.2 in example server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,5 @@ tokio-io = "0.1.12"
 tower-service = "0.2.0"
 
 [dev-dependencies]
+env_logger = "0.6.2"
 tokio = "0.1.22"

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -49,6 +49,8 @@ impl LanguageServer for Backend {
 }
 
 fn main() {
+    env_logger::init();
+
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 


### PR DESCRIPTION
### Changed

* Use `env_logger` version 0.6.2 in example server.