### PR TITLE
Implement workspace server requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ consists of three parts:
 ```rust
 use futures::future;
 use jsonrpc_core::{BoxFuture, Result};
+use serde_json::Value;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{LanguageServer, LspService, Printer, Server};
 
@@ -49,6 +50,8 @@ struct Backend;
 
 impl LanguageServer for Backend {
     type ShutdownFuture = BoxFuture<()>;
+    type SymbolFuture = BoxFuture<Option<Vec<SymbolInformation>>>;
+    type ExecuteFuture = BoxFuture<Option<Value>>;
     type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
     type HoverFuture = BoxFuture<Option<Hover>>;
 
@@ -62,6 +65,14 @@ impl LanguageServer for Backend {
 
     fn shutdown(&self) -> Self::ShutdownFuture {
         Box::new(future::ok(()))
+    }
+
+    fn symbol(&self, _: WorkspaceSymbolParams) -> Self::SymbolFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn execute_command(&self, _: &Printer, _: ExecuteCommandParams) -> Self::ExecuteFuture {
+        Box::new(future::ok(None))
     }
 
     fn hover(&self, _: TextDocumentPositionParams) -> Self::HoverFuture {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -30,6 +30,18 @@ impl LanguageServer for Backend {
         Box::new(future::ok(None))
     }
 
+    fn did_change_workspace_folders(&self, printer: &Printer, _: DidChangeWorkspaceFoldersParams) {
+        printer.log_message(MessageType::Info, "workspace folders changed!");
+    }
+
+    fn did_change_configuration(&self, printer: &Printer, _: DidChangeConfigurationParams) {
+        printer.log_message(MessageType::Info, "configuration changed!");
+    }
+
+    fn did_change_watched_files(&self, printer: &Printer, _: DidChangeWatchedFilesParams) {
+        printer.log_message(MessageType::Info, "watched files have changed!");
+    }
+
     fn execute_command(&self, printer: &Printer, _: ExecuteCommandParams) -> Self::ExecuteFuture {
         printer.apply_edit(WorkspaceEdit::default());
         Box::new(future::ok(None))

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,5 +1,6 @@
 use futures::future;
 use jsonrpc_core::{BoxFuture, Result};
+use serde_json::Value;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{LanguageServer, LspService, Printer, Server};
 
@@ -8,6 +9,8 @@ struct Backend;
 
 impl LanguageServer for Backend {
     type ShutdownFuture = BoxFuture<()>;
+    type SymbolFuture = BoxFuture<Option<Vec<SymbolInformation>>>;
+    type ExecuteFuture = BoxFuture<Option<Value>>;
     type HoverFuture = BoxFuture<Option<Hover>>;
     type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
 
@@ -21,6 +24,15 @@ impl LanguageServer for Backend {
 
     fn shutdown(&self) -> Self::ShutdownFuture {
         Box::new(future::ok(()))
+    }
+
+    fn symbol(&self, _: WorkspaceSymbolParams) -> Self::SymbolFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn execute_command(&self, printer: &Printer, _: ExecuteCommandParams) -> Self::ExecuteFuture {
+        printer.apply_edit(WorkspaceEdit::default());
+        Box::new(future::ok(None))
     }
 
     fn did_open(&self, printer: &Printer, _: DidOpenTextDocumentParams) {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -8,8 +8,8 @@ struct Backend;
 
 impl LanguageServer for Backend {
     type ShutdownFuture = BoxFuture<()>;
-    type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
     type HoverFuture = BoxFuture<Option<Hover>>;
+    type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
 
     fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult::default())

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -43,6 +43,7 @@ impl LanguageServer for Backend {
     }
 
     fn execute_command(&self, printer: &Printer, _: ExecuteCommandParams) -> Self::ExecuteFuture {
+        printer.log_message(MessageType::Info, "command executed!");
         printer.apply_edit(WorkspaceEdit::default());
         Box::new(future::ok(None))
     }

--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -11,7 +11,10 @@ use jsonrpc_core::types::{ErrorCode, Params};
 use jsonrpc_core::{BoxFuture, Error, Result as RpcResult};
 use jsonrpc_derive::rpc;
 use log::{error, trace};
+use lsp_types::notification::{Notification, *};
+use lsp_types::request::{Request, *};
 use lsp_types::*;
+use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 use super::LanguageServer;
@@ -46,6 +49,15 @@ pub trait LanguageServerCore {
     fn shutdown(&self) -> BoxFuture<()>;
 
     // Workspace
+
+    #[rpc(name = "workspace/didChangeWorkspaceFolders", raw_params)]
+    fn did_change_workspace_folders(&self, params: Params);
+
+    #[rpc(name = "workspace/DidChangeConfiguration", raw_params)]
+    fn did_change_configuration(&self, params: Params);
+
+    #[rpc(name = "workspace/didChangeWatchedFiles", raw_params)]
+    fn did_change_watched_files(&self, params: Params);
 
     #[rpc(name = "workspace/symbol", raw_params)]
     fn symbol(&self, params: Params) -> BoxFuture<Option<Vec<SymbolInformation>>>;
@@ -98,6 +110,42 @@ impl<T: LanguageServer> Delegate<T> {
 
         (delegate, messages)
     }
+
+    fn delegate_notification<N, F>(&self, params: Params, delegate: F)
+    where
+        N: Notification,
+        N::Params: DeserializeOwned,
+        F: Fn(&Printer, N::Params),
+    {
+        trace!("received `{}` notification: {:?}", N::METHOD, params);
+        if self.initialized.load(Ordering::SeqCst) {
+            match params.parse::<N::Params>() {
+                Ok(params) => delegate(&self.printer, params),
+                Err(err) => error!("invalid parameters for `{}`: {:?}", N::METHOD, err),
+            }
+        }
+    }
+
+    fn delegate_request<R, F>(&self, params: Params, delegate: F) -> BoxFuture<R::Result>
+    where
+        R: Request,
+        R::Params: DeserializeOwned,
+        R::Result: Send + 'static,
+        F: Fn(R::Params) -> BoxFuture<R::Result>,
+    {
+        trace!("received `{}` request: {:?}", R::METHOD, params);
+        if self.initialized.load(Ordering::SeqCst) {
+            match params.parse() {
+                Ok(params) => delegate(params),
+                Err(err) => Box::new(future::err(Error::invalid_params_with_details(
+                    "invalid parameters",
+                    err,
+                ))),
+            }
+        } else {
+            Box::new(future::err(not_initialized_error()))
+        }
+    }
 }
 
 impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
@@ -110,13 +158,9 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
     }
 
     fn initialized(&self, params: Params) {
-        trace!("received `initialized` notification: {:?}", params);
-        if self.initialized.load(Ordering::SeqCst) {
-            match params.parse::<InitializedParams>() {
-                Ok(params) => self.server.initialized(&self.printer, params),
-                Err(err) => error!("invalid parameters for `initialized`: {:?}", err),
-            }
-        }
+        self.delegate_notification::<Initialized, _>(params, |p, params| {
+            self.server.initialized(p, params)
+        });
     }
 
     fn shutdown(&self) -> BoxFuture<()> {
@@ -128,113 +172,66 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
         }
     }
 
+    fn did_change_workspace_folders(&self, params: Params) {
+        self.delegate_notification::<DidChangeWorkspaceFolders, _>(params, |p, params| {
+            self.server.did_change_workspace_folders(p, params)
+        });
+    }
+
+    fn did_change_configuration(&self, params: Params) {
+        self.delegate_notification::<DidChangeConfiguration, _>(params, |p, params| {
+            self.server.did_change_configuration(p, params)
+        });
+    }
+
+    fn did_change_watched_files(&self, params: Params) {
+        self.delegate_notification::<DidChangeWatchedFiles, _>(params, |p, params| {
+            self.server.did_change_watched_files(p, params)
+        });
+    }
+
     fn symbol(&self, params: Params) -> BoxFuture<Option<Vec<SymbolInformation>>> {
-        trace!("received `workspace/symbol` request: {:?}", params);
-        if self.initialized.load(Ordering::SeqCst) {
-            match params.parse::<WorkspaceSymbolParams>() {
-                Ok(params) => Box::new(self.server.symbol(params)),
-                Err(err) => Box::new(future::err(Error::invalid_params_with_details(
-                    "invalid parameters",
-                    err,
-                ))),
-            }
-        } else {
-            Box::new(future::err(not_initialized_error()))
-        }
+        self.delegate_request::<WorkspaceSymbol, _>(params, |p| Box::new(self.server.symbol(p)))
     }
 
     fn execute_command(&self, params: Params) -> BoxFuture<Option<Value>> {
-        trace!("received `workspace/executeCommand` request: {:?}", params);
-        if self.initialized.load(Ordering::SeqCst) {
-            match params.parse::<ExecuteCommandParams>() {
-                Ok(params) => Box::new(self.server.execute_command(&self.printer, params)),
-                Err(err) => Box::new(future::err(Error::invalid_params_with_details(
-                    "invalid parameters",
-                    err,
-                ))),
-            }
-        } else {
-            Box::new(future::err(not_initialized_error()))
-        }
+        self.delegate_request::<ExecuteCommand, _>(params, |p| {
+            Box::new(self.server.execute_command(&self.printer, p))
+        })
     }
 
     fn did_open(&self, params: Params) {
-        trace!("received `textDocument/didOpen` notification: {:?}", params);
-        if self.initialized.load(Ordering::SeqCst) {
-            match params.parse::<DidOpenTextDocumentParams>() {
-                Ok(params) => self.server.did_open(&self.printer, params),
-                Err(err) => error!("invalid parameters for `textDocument/didOpen`: {:?}", err),
-            }
-        }
+        self.delegate_notification::<DidOpenTextDocument, _>(params, |p, params| {
+            self.server.did_open(p, params)
+        });
     }
 
     fn did_change(&self, params: Params) {
-        trace!(
-            "received `textDocument/didChange` notification: {:?}",
-            params
-        );
-        if self.initialized.load(Ordering::SeqCst) {
-            match params.parse::<DidChangeTextDocumentParams>() {
-                Ok(params) => self.server.did_change(&self.printer, params),
-                Err(err) => error!("invalid parameters for `textDocument/didChange`: {:?}", err),
-            }
-        }
+        self.delegate_notification::<DidChangeTextDocument, _>(params, |p, params| {
+            self.server.did_change(p, params)
+        });
     }
 
     fn did_save(&self, params: Params) {
-        trace!("received `textDocument/didSave` notification: {:?}", params);
-        if self.initialized.load(Ordering::SeqCst) {
-            match params.parse::<DidSaveTextDocumentParams>() {
-                Ok(params) => self.server.did_save(&self.printer, params),
-                Err(err) => error!("invalid parameters for `textDocument/didSave`: {:?}", err),
-            }
-        }
+        self.delegate_notification::<DidSaveTextDocument, _>(params, |p, params| {
+            self.server.did_save(p, params)
+        });
     }
 
     fn did_close(&self, params: Params) {
-        trace!(
-            "received `textDocument/didClose` notification: {:?}",
-            params
-        );
-        if self.initialized.load(Ordering::SeqCst) {
-            match params.parse::<DidCloseTextDocumentParams>() {
-                Ok(params) => self.server.did_close(&self.printer, params),
-                Err(err) => error!("invalid parameters for `textDocument/didClose`: {:?}", err),
-            }
-        }
+        self.delegate_notification::<DidCloseTextDocument, _>(params, |p, params| {
+            self.server.did_close(p, params)
+        });
     }
 
     fn hover(&self, params: Params) -> BoxFuture<Option<Hover>> {
-        trace!("received `textDocument/hover` request: {:?}", params);
-        if self.initialized.load(Ordering::SeqCst) {
-            match params.parse::<TextDocumentPositionParams>() {
-                Ok(params) => Box::new(self.server.hover(params)),
-                Err(err) => Box::new(future::err(Error::invalid_params_with_details(
-                    "invalid parameters",
-                    err,
-                ))),
-            }
-        } else {
-            Box::new(future::err(not_initialized_error()))
-        }
+        self.delegate_request::<HoverRequest, _>(params, |p| Box::new(self.server.hover(p)))
     }
 
     fn document_highlight(&self, params: Params) -> BoxFuture<Option<Vec<DocumentHighlight>>> {
-        trace!(
-            "received `textDocument/documentHighlight` request: {:?}",
-            params
-        );
-        if self.initialized.load(Ordering::SeqCst) {
-            match params.parse::<TextDocumentPositionParams>() {
-                Ok(params) => Box::new(self.server.document_highlight(params)),
-                Err(err) => Box::new(future::err(Error::invalid_params_with_details(
-                    "invalid parameters",
-                    err,
-                ))),
-            }
-        } else {
-            Box::new(future::err(not_initialized_error()))
-        }
+        self.delegate_request::<DocumentHighlightRequest, _>(params, |p| {
+            Box::new(self.server.document_highlight(p))
+        })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,48 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// [`exit`]: https://microsoft.github.io/language-server-protocol/specification#exit
     fn shutdown(&self) -> Self::ShutdownFuture;
 
+    /// The [`workspace/didChangeWorkspaceFolders`] notification is sent from the client to the
+    /// server to inform about workspace folder configuration changes.
+    ///
+    /// The notification is sent by default if both of these boolean fields were set to `true` in
+    /// the [`initialize`] method:
+    ///
+    /// * `InitializeParams::capabilities::workspace::workspace_folders`
+    /// * `InitializeResult::capabilities::workspace::workspace_folders::supported`
+    ///
+    /// This notification is also sent if the server has registered itself to receive this
+    /// notification.
+    ///
+    /// [`workspace/didChangeWorkspaceFolders`]: https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeWorkspaceFolders
+    /// [`initialize`]: #tymethod.initialize
+    fn did_change_workspace_folders(&self, p: &Printer, params: DidChangeWorkspaceFoldersParams) {
+        let _ = p;
+        let _ = params;
+    }
+
+    /// The [`workspace/didChangeConfiguration`] notification is sent from the client to the server
+    /// to signal the change of configuration settings.
+    ///
+    /// [`workspace/didChangeConfiguration`]: https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeConfiguration
+    fn did_change_configuration(&self, printer: &Printer, params: DidChangeConfigurationParams) {
+        let _ = printer;
+        let _ = params;
+    }
+
+    /// The [`workspace/didChangeWatchedFiles`] notification is sent from the client to the server
+    /// when the client detects changes to files watched by the language client.
+    ///
+    /// It is recommended that servers register for these file events using the registration
+    /// mechanism. This can be done here or in the [`initialized`] method using
+    /// `Printer::register_capability()`.
+    ///
+    /// [`workspace/didChangeWatchedFiles`]: https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeConfiguration
+    /// [`initialized`]: #tymethod.initialized
+    fn did_change_watched_files(&self, printer: &Printer, params: DidChangeWatchedFilesParams) {
+        let _ = printer;
+        let _ = params;
+    }
+
     /// The [`workspace/symbol`] request is sent from the client to the server to list project-wide
     /// symbols matching the given query string.
     ///
@@ -232,6 +274,18 @@ impl<S: ?Sized + LanguageServer> LanguageServer for Box<S> {
 
     fn shutdown(&self) -> Self::ShutdownFuture {
         (**self).shutdown()
+    }
+
+    fn did_change_workspace_folders(&self, p: &Printer, params: DidChangeWorkspaceFoldersParams) {
+        (**self).did_change_workspace_folders(p, params);
+    }
+
+    fn did_change_configuration(&self, printer: &Printer, params: DidChangeConfigurationParams) {
+        (**self).did_change_configuration(printer, params);
+    }
+
+    fn did_change_watched_files(&self, printer: &Printer, params: DidChangeWatchedFilesParams) {
+        (**self).did_change_watched_files(printer, params);
     }
 
     fn symbol(&self, params: WorkspaceSymbolParams) -> Self::SymbolFuture {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@
 //!
 //! impl LanguageServer for Backend {
 //!     type ShutdownFuture = BoxFuture<()>;
-//!     type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
 //!     type HoverFuture = BoxFuture<Option<Hover>>;
+//!     type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
 //!
 //!     fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
 //!         Ok(InitializeResult::default())
@@ -83,10 +83,10 @@ mod stdio;
 pub trait LanguageServer: Send + Sync + 'static {
     /// Response returned when a server shutdown is requested.
     type ShutdownFuture: Future<Item = (), Error = Error> + Send;
-    /// Response returned when a document highlight action is requested.
-    type HighlightFuture: Future<Item = Option<Vec<DocumentHighlight>>, Error = Error> + Send;
     /// Response returned when a hover action is requested.
     type HoverFuture: Future<Item = Option<Hover>, Error = Error> + Send;
+    /// Response returned when a document highlight action is requested.
+    type HighlightFuture: Future<Item = Option<Vec<DocumentHighlight>>, Error = Error> + Send;
 
     /// The [`initialize`] request is the first request sent from the client to the server.
     ///
@@ -184,8 +184,8 @@ pub trait LanguageServer: Send + Sync + 'static {
 
 impl<S: ?Sized + LanguageServer> LanguageServer for Box<S> {
     type ShutdownFuture = S::ShutdownFuture;
-    type HighlightFuture = S::HighlightFuture;
     type HoverFuture = S::HoverFuture;
+    type HighlightFuture = S::HighlightFuture;
 
     fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
         (**self).initialize(params)

--- a/src/service.rs
+++ b/src/service.rs
@@ -173,6 +173,7 @@ impl Service<Incoming> for LspService {
 mod tests {
     use jsonrpc_core::{BoxFuture, Result};
     use lsp_types::*;
+    use serde_json::Value;
 
     use super::*;
     use crate::Printer;
@@ -182,6 +183,8 @@ mod tests {
 
     impl LanguageServer for Mock {
         type ShutdownFuture = BoxFuture<()>;
+        type SymbolFuture = BoxFuture<Option<Vec<SymbolInformation>>>;
+        type ExecuteFuture = BoxFuture<Option<Value>>;
         type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
         type HoverFuture = BoxFuture<Option<Hover>>;
 
@@ -189,19 +192,17 @@ mod tests {
             Ok(InitializeResult::default())
         }
 
-        fn initialized(&self, _: &Printer, _: InitializedParams) {}
-
         fn shutdown(&self) -> Self::ShutdownFuture {
             Box::new(future::ok(()))
         }
 
-        fn did_open(&self, _: &Printer, _: DidOpenTextDocumentParams) {}
+        fn symbol(&self, _: WorkspaceSymbolParams) -> Self::SymbolFuture {
+            Box::new(future::ok(None))
+        }
 
-        fn did_change(&self, _: &Printer, _: DidChangeTextDocumentParams) {}
-
-        fn did_save(&self, _: &Printer, _: DidSaveTextDocumentParams) {}
-
-        fn did_close(&self, _: &Printer, _: DidCloseTextDocumentParams) {}
+        fn execute_command(&self, _: &Printer, _: ExecuteCommandParams) -> Self::ExecuteFuture {
+            Box::new(future::ok(None))
+        }
 
         fn hover(&self, _: TextDocumentPositionParams) -> Self::HoverFuture {
             Box::new(future::ok(None))


### PR DESCRIPTION
### Added

* Move `HighlightFuture` associated type to bottom in all occurrences.
* Implement `workspace/symbol` and `workspace/executeCommand` requests.
* Implement all server-side `workspace` notifications.

### Changed

* Clean up delegation boilerplate with `delegate_request()` and `delegate_notification()` methods.
* Update example server to log on every `workspace` notification and also on the `executeCommand` request.

Closes #8.