### PR TITLE
Fix copy-paste mistake in comment

### DIFF
--- a/src/delegate/printer.rs
+++ b/src/delegate/printer.rs
@@ -151,7 +151,7 @@ where
     N::Params: Serialize,
 {
     // Since these types come from the `lsp-types` crate and validity is enforced via the
-    // `Notification` trait, the `unwrap()` calls below should never fail.
+    // `Request` trait, the `unwrap()` calls below should never fail.
     let output = serde_json::to_string(&params).unwrap();
     let params = serde_json::from_str(&output).unwrap();
     serde_json::to_string(&request::MethodCall {


### PR DESCRIPTION
### Fixed

* Fix copy-paste mistake in comment inside `make_request()`.