### PR TITLE
Allow telemetry/event data to be null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* Allow JSON data for `telemetry/event` notification to be null.
+
 ## [0.3.0] - 2019-09-05
 
 ### Added

--- a/src/delegate/printer.rs
+++ b/src/delegate/printer.rs
@@ -64,7 +64,7 @@ impl Printer {
         match serde_json::to_value(data) {
             Err(e) => error!("invalid JSON in `telemetry/event` notification: {}", e),
             Ok(value) => {
-                if !value.is_array() && !value.is_object() {
+                if !value.is_null() && !value.is_array() && !value.is_object() {
                     let value = Value::Array(vec![value]);
                     self.send_message(make_notification::<TelemetryEvent>(value));
                 } else {


### PR DESCRIPTION
### Fixed

* Allow JSON data for `telemetry/event` to be null without wrapping it in an array. This ensures proper conversion to [`Params`](https://docs.rs/jsonrpc-core/13.1.0/jsonrpc_core/types/params/enum.Params.html).