### PR TITLE
Allow CI failures for nightly builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,21 +7,28 @@ jobs:
     name: Rust ${{ matrix.rust-version }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust-version: [1.34.0, beta, nightly]
+        include:
+        - rust-version: nightly
+          continue-on-error: true
 
     steps:
     - uses: hecrj/setup-rust-action@master
       with:
         rust-version: ${{ matrix.rust-version }}
+
     - uses: actions/checkout@v1
+
     - name: Check formatting
+      continue-on-error: ${{ matrix.continue-on-error }}
       run: |
         rustup component add rustfmt
         cargo fmt --all -- --check
     - name: Build
+      continue-on-error: ${{ matrix.continue-on-error }}
       run: cargo build --all --verbose
     - name: Run tests
+      continue-on-error: ${{ matrix.continue-on-error }}
       run: cargo test --all --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,10 +18,9 @@ jobs:
     - uses: hecrj/setup-rust-action@master
       with:
         rust-version: ${{ matrix.rust-version }}
-
     - uses: actions/checkout@v1
-
     - name: Check formatting
+      if: matrix.rust-version != 'nightly'
       continue-on-error: ${{ matrix.continue-on-error }}
       run: |
         rustup component add rustfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,28 +7,21 @@ jobs:
     name: Rust ${{ matrix.rust-version }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust-version: [1.34.0, beta, nightly]
-        include:
-        - rust-version: nightly
-          continue-on-error: true
 
     steps:
     - uses: hecrj/setup-rust-action@master
       with:
         rust-version: ${{ matrix.rust-version }}
-
     - uses: actions/checkout@v1
-
     - name: Check formatting
-      continue-on-error: ${{ matrix.continue-on-error }}
       run: |
         rustup component add rustfmt
         cargo fmt --all -- --check
     - name: Build
-      continue-on-error: ${{ matrix.continue-on-error }}
       run: cargo build --all --verbose
     - name: Run tests
-      continue-on-error: ${{ matrix.continue-on-error }}
       run: cargo test --all --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,12 +15,31 @@ jobs:
     - uses: hecrj/setup-rust-action@master
       with:
         rust-version: ${{ matrix.rust-version }}
+
     - uses: actions/checkout@v1
+
     - name: Check formatting
       run: |
         rustup component add rustfmt
         cargo fmt --all -- --check
+    - name: Check formatting
+      if: matrix.rust-version == 'nightly'
+      continue-on-error: true
+      run: |
+        rustup component add rustfmt
+        cargo fmt --all -- --check
+
     - name: Build
       run: cargo build --all --verbose
+    - name: Build
+      if: matrix.rust-version == 'nightly'
+      continue-on-error: true
+      run: cargo build --all --verbose
+
     - name: Run tests
+      run: cargo test --all --verbose
+
+    - name: Run tests
+      if: matrix.rust-version == 'nightly'
+      continue-on-error: true
       run: cargo test --all --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,6 @@ jobs:
     - uses: actions/checkout@v1
     - name: Check formatting
       if: matrix.rust-version != 'nightly'
-      continue-on-error: ${{ matrix.continue-on-error }}
       run: |
         rustup component add rustfmt
         cargo fmt --all -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust-version: [1.34.0, beta, nightly]
+        continue-on-error: false
+        include:
+        - rust-version: nightly
+          continue-on-error: true
 
     steps:
     - uses: hecrj/setup-rust-action@master
@@ -19,29 +23,13 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Check formatting
-      if: matrix.rust-version != 'nightly'
+      continue-on-error: ${{ matrix.continue-on-error }}
       run: |
         rustup component add rustfmt
         cargo fmt --all -- --check
-    - name: Check formatting
-      if: matrix.rust-version == 'nightly'
-      continue-on-error: true
-      run: |
-        rustup component add rustfmt
-        cargo fmt --all -- --check
-
     - name: Build
-      if: matrix.rust-version != 'nightly'
+      continue-on-error: ${{ matrix.continue-on-error }}
       run: cargo build --all --verbose
-    - name: Build
-      if: matrix.rust-version == 'nightly'
-      continue-on-error: true
-      run: cargo build --all --verbose
-
     - name: Run tests
-      if: matrix.rust-version != 'nightly'
-      run: cargo test --all --verbose
-    - name: Run tests
-      if: matrix.rust-version == 'nightly'
-      continue-on-error: true
+      continue-on-error: ${{ matrix.continue-on-error }}
       run: cargo test --all --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Check formatting
+      if: matrix.rust-version != 'nightly'
       run: |
         rustup component add rustfmt
         cargo fmt --all -- --check
@@ -30,6 +31,7 @@ jobs:
         cargo fmt --all -- --check
 
     - name: Build
+      if: matrix.rust-version != 'nightly'
       run: cargo build --all --verbose
     - name: Build
       if: matrix.rust-version == 'nightly'
@@ -37,8 +39,8 @@ jobs:
       run: cargo build --all --verbose
 
     - name: Run tests
+      if: matrix.rust-version != 'nightly'
       run: cargo test --all --verbose
-
     - name: Run tests
       if: matrix.rust-version == 'nightly'
       continue-on-error: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust-version: [1.34.0, beta, nightly]
-        continue-on-error: false
         include:
         - rust-version: nightly
           continue-on-error: true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,8 @@ use jsonrpc_core::{Error, Result};
 use lsp_types::*;
 use serde_json::Value;
 
+this should not compile
+
 mod codec;
 mod delegate;
 mod message;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,6 @@ use jsonrpc_core::{Error, Result};
 use lsp_types::*;
 use serde_json::Value;
 
-this should not compile
-
 mod codec;
 mod delegate;
 mod message;


### PR DESCRIPTION
### Changed

* Use [`continue-on-error`](https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) to allow CI failures on nightly Rust.
* Skip formatting checks on nightly.

In this case, we use matrix substitution in the form of `${{ matrix.continue-on-error }}` to template the value into each step. This value is only defined in `nightly` builds to be `true`, and GitHub actions sets the value to be `false` in all steps otherwise.

We do not disable `jobs.build.strategy.fail-fast` because we want the build to abort if a regression is found against the `beta` release channel.