### PR TITLE
Add support for textDocument/completion request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Implement support for the following client-to-server message:
+  * `textDocument/completion`
+
 ## [0.3.1] - 2019-09-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ impl LanguageServer for Backend {
     type ShutdownFuture = BoxFuture<()>;
     type SymbolFuture = BoxFuture<Option<Vec<SymbolInformation>>>;
     type ExecuteFuture = BoxFuture<Option<Value>>;
+    type CompletionFuture = BoxFuture<Option<CompletionResponse>>;
     type HoverFuture = BoxFuture<Option<Hover>>;
     type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
 
@@ -72,6 +73,10 @@ impl LanguageServer for Backend {
     }
 
     fn execute_command(&self, _: &Printer, _: ExecuteCommandParams) -> Self::ExecuteFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn completion(&self, _: CompletionParams) -> Self::CompletionFuture {
         Box::new(future::ok(None))
     }
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -11,6 +11,7 @@ impl LanguageServer for Backend {
     type ShutdownFuture = BoxFuture<()>;
     type SymbolFuture = BoxFuture<Option<Vec<SymbolInformation>>>;
     type ExecuteFuture = BoxFuture<Option<Value>>;
+    type CompletionFuture = BoxFuture<Option<CompletionResponse>>;
     type HoverFuture = BoxFuture<Option<Hover>>;
     type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
 
@@ -90,6 +91,10 @@ impl LanguageServer for Backend {
 
     fn did_close(&self, printer: &Printer, _: DidCloseTextDocumentParams) {
         printer.log_message(MessageType::Info, "file closed!");
+    }
+
+    fn completion(&self, _: CompletionParams) -> Self::CompletionFuture {
+        Box::new(future::ok(None))
     }
 
     fn hover(&self, _: TextDocumentPositionParams) -> Self::HoverFuture {

--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -81,6 +81,9 @@ pub trait LanguageServerCore {
 
     // Language features
 
+    #[rpc(name = "textDocument/completion", raw_params)]
+    fn completion(&self, params: Params) -> BoxFuture<Option<CompletionResponse>>;
+
     #[rpc(name = "textDocument/hover", raw_params)]
     fn hover(&self, params: Params) -> BoxFuture<Option<Hover>>;
 
@@ -222,6 +225,10 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
         self.delegate_notification::<DidCloseTextDocument, _>(params, |p, params| {
             self.server.did_close(p, params)
         });
+    }
+
+    fn completion(&self, params: Params) -> BoxFuture<Option<CompletionResponse>> {
+        self.delegate_request::<Completion, _>(params, |p| Box::new(self.server.completion(p)))
     }
 
     fn hover(&self, params: Params) -> BoxFuture<Option<Hover>> {

--- a/src/service.rs
+++ b/src/service.rs
@@ -185,6 +185,7 @@ mod tests {
         type ShutdownFuture = BoxFuture<()>;
         type SymbolFuture = BoxFuture<Option<Vec<SymbolInformation>>>;
         type ExecuteFuture = BoxFuture<Option<Value>>;
+        type CompletionFuture = BoxFuture<Option<CompletionResponse>>;
         type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
         type HoverFuture = BoxFuture<Option<Hover>>;
 
@@ -201,6 +202,10 @@ mod tests {
         }
 
         fn execute_command(&self, _: &Printer, _: ExecuteCommandParams) -> Self::ExecuteFuture {
+            Box::new(future::ok(None))
+        }
+
+        fn completion(&self, _: CompletionParams) -> Self::CompletionFuture {
             Box::new(future::ok(None))
         }
 


### PR DESCRIPTION
### Added

* Implement support for `textDocument/completion` request.

### Changed

* Update `CHANGELOG.md`.

This pull request is one step toward resolving #10.