### PR TITLE
Permit some server-to-client messages when uninitialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-* Implement support for the following client-to-server message:
-  * `textDocument/completion`
+* Implement support for `textDocument/completion` request.
+
+### Changed
+
+* Expose `Printer` in `LanguageServer::initialize()`.
+
+### Fixed
+
+* Allow `window/logMessage`, `window/showMessage`, and `telemetry/event`
+  server-to-client notifications in `initialize` request (PR #48).
 
 ## [0.3.1] - 2019-09-08
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ impl LanguageServer for Backend {
     type HoverFuture = BoxFuture<Option<Hover>>;
     type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
 
-    fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
+    fn initialize(&self, _: &Printer, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult::default())
     }
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -15,7 +15,7 @@ impl LanguageServer for Backend {
     type HoverFuture = BoxFuture<Option<Hover>>;
     type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
 
-    fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
+    fn initialize(&self, _: &Printer, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(

--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -155,7 +155,7 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
     fn initialize(&self, params: Params) -> RpcResult<InitializeResult> {
         trace!("received `initialize` request: {:?}", params);
         let params: InitializeParams = params.parse()?;
-        let response = self.server.initialize(params)?;
+        let response = self.server.initialize(&self.printer, params)?;
         self.initialized.store(true, Ordering::SeqCst);
         Ok(response)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //!     type HoverFuture = BoxFuture<Option<Hover>>;
 //!     type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
 //!
-//!     fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
+//!     fn initialize(&self, _: &Printer, _: InitializeParams) -> Result<InitializeResult> {
 //!         Ok(InitializeResult::default())
 //!     }
 //!
@@ -114,7 +114,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// The [`initialize`] request is the first request sent from the client to the server.
     ///
     /// [`initialize`]: https://microsoft.github.io/language-server-protocol/specification#initialize
-    fn initialize(&self, params: InitializeParams) -> Result<InitializeResult>;
+    fn initialize(&self, printer: &Printer, params: InitializeParams) -> Result<InitializeResult>;
 
     /// The [`initialized`] notification is sent from the client to the server after the client
     /// received the result of the initialize request but before the client sends anything else.
@@ -280,8 +280,8 @@ impl<S: ?Sized + LanguageServer> LanguageServer for Box<S> {
     type HoverFuture = S::HoverFuture;
     type HighlightFuture = S::HighlightFuture;
 
-    fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
-        (**self).initialize(params)
+    fn initialize(&self, printer: &Printer, params: InitializeParams) -> Result<InitializeResult> {
+        (**self).initialize(printer, params)
     }
 
     fn initialized(&self, printer: &Printer, params: InitializedParams) {

--- a/src/service.rs
+++ b/src/service.rs
@@ -189,7 +189,7 @@ mod tests {
         type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
         type HoverFuture = BoxFuture<Option<Hover>>;
 
-        fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
+        fn initialize(&self, _: &Printer, _: InitializeParams) -> Result<InitializeResult> {
             Ok(InitializeResult::default())
         }
 


### PR DESCRIPTION
### Changed

* Expose `Printer` in `LanguageServer::initialize()`.

### Fixed

* Allow `window/logMessage`, `window/showMessage`, and `telemetry/event` server-to-client notifications in `initialize` request.

Fixes #47.