### PR TITLE
Prepare release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Retain error or success from future in `ExitReceiver::run_until_exit()`.
 * Remove `'static` bounds on some `Server` and `ExitReceiver` methods.
 
-[init]: https://microsoft.github.io/language-server-protocol/specification#initialize
+[init]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#initialize
 
 ## [0.1.0] - 2019-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.4.0] - 2019-10-02
+
 ### Added
 
 * Implement support for `textDocument/completion` request.
@@ -14,11 +16,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 * Expose `Printer` in `LanguageServer::initialize()`.
+* Update `env_logger` crate from 0.6.2 to 0.7.0.
+* Update `lsp-types` crate from 0.60.0 to 0.61.0.
 
 ### Fixed
 
 * Allow `window/logMessage`, `window/showMessage`, and `telemetry/event`
   server-to-client notifications in `initialize` request (PR #48).
+* Update links to the LSP specification website to point to the new URL.
 
 ## [0.3.1] - 2019-09-08
 
@@ -102,7 +107,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * `textDocument/hover`
   * `textDocument/documentHighlight`
 
-[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.1.0...v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 edition = "2018"
 description = "Language Server Protocol implementation based on Tower"

--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -244,8 +244,8 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
 
 /// Error response returned for every request received before the server is initialized.
 ///
-/// See [here](https://microsoft.github.io/language-server-protocol/specification#initialize) for
-/// reference.
+/// See [here](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#initialize)
+/// for reference.
 fn not_initialized_error() -> Error {
     Error {
         code: ErrorCode::ServerError(-32002),

--- a/src/delegate/printer.rs
+++ b/src/delegate/printer.rs
@@ -35,7 +35,7 @@ impl Printer {
     ///
     /// This corresponds to the [`window/logMessage`] notification.
     ///
-    /// [`window/logMessage`]: https://microsoft.github.io/language-server-protocol/specification#window_logMessage
+    /// [`window/logMessage`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#window_logMessage
     pub fn log_message<M: Display>(&self, typ: MessageType, message: M) {
         self.send_message(make_notification::<LogMessage>(LogMessageParams {
             typ,
@@ -47,7 +47,7 @@ impl Printer {
     ///
     /// This corresponds to the [`window/showMessage`] notification.
     ///
-    /// [`window/showMessage`]: https://microsoft.github.io/language-server-protocol/specification#window_showMessage
+    /// [`window/showMessage`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#window_showMessage
     pub fn show_message<M: Display>(&self, typ: MessageType, message: M) {
         self.send_message(make_notification::<ShowMessage>(ShowMessageParams {
             typ,
@@ -59,7 +59,7 @@ impl Printer {
     ///
     /// This corresponds to the [`telemetry/event`] notification.
     ///
-    /// [`telemetry/event`]: https://microsoft.github.io/language-server-protocol/specification#telemetry_event
+    /// [`telemetry/event`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#telemetry_event
     pub fn telemetry_event<S: Serialize>(&self, data: S) {
         match serde_json::to_value(data) {
             Err(e) => error!("invalid JSON in `telemetry/event` notification: {}", e),
@@ -78,7 +78,7 @@ impl Printer {
     ///
     /// This corresponds to the [`client/registerCapability`] request.
     ///
-    /// [`client/registerCapability`]: https://microsoft.github.io/language-server-protocol/specification#client_registerCapability
+    /// [`client/registerCapability`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#client_registerCapability
     pub fn register_capability(&self, registrations: Vec<Registration>) {
         // FIXME: Check whether the request succeeded or failed.
         let id = self.request_id.fetch_add(1, Ordering::SeqCst);
@@ -92,7 +92,7 @@ impl Printer {
     ///
     /// This corresponds to the [`client/unregisterCapability`] request.
     ///
-    /// [`client/unregisterCapability`]: https://microsoft.github.io/language-server-protocol/specification#client_unregisterCapability
+    /// [`client/unregisterCapability`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#client_unregisterCapability
     pub fn unregister_capability(&self, unregisterations: Vec<Unregistration>) {
         // FIXME: Check whether the request succeeded or failed.
         let id = self.request_id.fetch_add(1, Ordering::SeqCst);
@@ -107,7 +107,7 @@ impl Printer {
     ///
     /// This corresponds to the [`workspace/applyEdit`] request.
     ///
-    /// [`workspace/applyEdit`]: https://microsoft.github.io/language-server-protocol/specification#workspace_applyEdit
+    /// [`workspace/applyEdit`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#workspace_applyEdit
     pub fn apply_edit(&self, edit: WorkspaceEdit) -> bool {
         // FIXME: Check whether the request succeeded or failed and retrieve apply status.
         let id = self.request_id.fetch_add(1, Ordering::SeqCst);
@@ -122,7 +122,7 @@ impl Printer {
     ///
     /// This corresponds to the [`textDocument/publishDiagnostics`] notification.
     ///
-    /// [`textDocument/publishDiagnostics`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_publishDiagnostics
+    /// [`textDocument/publishDiagnostics`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_publishDiagnostics
     pub fn publish_diagnostics(&self, uri: Url, diagnostics: Vec<Diagnostic>) {
         self.send_message_initialized(make_notification::<PublishDiagnostics>(
             PublishDiagnosticsParams::new(uri, diagnostics),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ pub trait LanguageServer: Send + Sync + 'static {
 
     /// The [`initialize`] request is the first request sent from the client to the server.
     ///
-    /// [`initialize`]: https://microsoft.github.io/language-server-protocol/specification#initialize
+    /// [`initialize`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#initialize
     fn initialize(&self, printer: &Printer, params: InitializeParams) -> Result<InitializeResult>;
 
     /// The [`initialized`] notification is sent from the client to the server after the client
@@ -122,7 +122,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// The server can use the `initialized` notification for example to dynamically register
     /// capabilities with the client.
     ///
-    /// [`initialized`]: https://microsoft.github.io/language-server-protocol/specification#initialized
+    /// [`initialized`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#initialized
     fn initialized(&self, printer: &Printer, params: InitializedParams) {
         let _ = printer;
         let _ = params;
@@ -133,8 +133,8 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// This request is often later followed by an [`exit`] notification, which will cause the
     /// server to exit immediately.
     ///
-    /// [`shutdown`]: https://microsoft.github.io/language-server-protocol/specification#shutdown
-    /// [`exit`]: https://microsoft.github.io/language-server-protocol/specification#exit
+    /// [`shutdown`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#shutdown
+    /// [`exit`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#exit
     fn shutdown(&self) -> Self::ShutdownFuture;
 
     /// The [`workspace/didChangeWorkspaceFolders`] notification is sent from the client to the
@@ -149,7 +149,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// This notification is also sent if the server has registered itself to receive this
     /// notification.
     ///
-    /// [`workspace/didChangeWorkspaceFolders`]: https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeWorkspaceFolders
+    /// [`workspace/didChangeWorkspaceFolders`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#workspace_didChangeWorkspaceFolders
     /// [`initialize`]: #tymethod.initialize
     fn did_change_workspace_folders(&self, p: &Printer, params: DidChangeWorkspaceFoldersParams) {
         let _ = p;
@@ -159,7 +159,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// The [`workspace/didChangeConfiguration`] notification is sent from the client to the server
     /// to signal the change of configuration settings.
     ///
-    /// [`workspace/didChangeConfiguration`]: https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeConfiguration
+    /// [`workspace/didChangeConfiguration`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#workspace_didChangeConfiguration
     fn did_change_configuration(&self, printer: &Printer, params: DidChangeConfigurationParams) {
         let _ = printer;
         let _ = params;
@@ -172,7 +172,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// mechanism. This can be done here or in the [`initialized`] method using
     /// `Printer::register_capability()`.
     ///
-    /// [`workspace/didChangeWatchedFiles`]: https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeConfiguration
+    /// [`workspace/didChangeWatchedFiles`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#workspace_didChangeConfiguration
     /// [`initialized`]: #tymethod.initialized
     fn did_change_watched_files(&self, printer: &Printer, params: DidChangeWatchedFilesParams) {
         let _ = printer;
@@ -182,7 +182,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// The [`workspace/symbol`] request is sent from the client to the server to list project-wide
     /// symbols matching the given query string.
     ///
-    /// [`workspace/symbol`]: https://microsoft.github.io/language-server-protocol/specification#workspace_symbol
+    /// [`workspace/symbol`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#workspace_symbol
     fn symbol(&self, params: WorkspaceSymbolParams) -> Self::SymbolFuture;
 
     /// The [`workspace/executeCommand`] request is sent from the client to the server to trigger
@@ -191,7 +191,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// In most cases, the server creates a `WorkspaceEdit` structure and applies the changes to
     /// the workspace using `Printer::apply_edit()` before returning from this function.
     ///
-    /// [`workspace/executeCommand`]: https://microsoft.github.io/language-server-protocol/specification#workspace_executeCommand
+    /// [`workspace/executeCommand`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#workspace_executeCommand
     fn execute_command(&self, p: &Printer, params: ExecuteCommandParams) -> Self::ExecuteFuture;
 
     /// The [`textDocument/didOpen`] notification is sent from the client to the server to signal
@@ -201,7 +201,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// document’s truth using the document's URI. "Open" in this sense means it is managed by the
     /// client. It doesn't necessarily mean that its content is presented in an editor.
     ///
-    /// [`textDocument/didOpen`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_didOpen
+    /// [`textDocument/didOpen`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_didOpen
     fn did_open(&self, printer: &Printer, params: DidOpenTextDocumentParams) {
         let _ = printer;
         let _ = params;
@@ -213,7 +213,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// This notification will contain a distinct version tag and a list of edits made to the
     /// document for the server to interpret.
     ///
-    /// [`textDocument/didChange`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_didChange
+    /// [`textDocument/didChange`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_didChange
     fn did_change(&self, printer: &Printer, params: DidChangeTextDocumentParams) {
         let _ = printer;
         let _ = params;
@@ -222,7 +222,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// The [`textDocument/didSave`] notification is sent from the client to the server when the
     /// document was saved in the client.
     ///
-    /// [`textDocument/didSave`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_didSave
+    /// [`textDocument/didSave`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_didSave
     fn did_save(&self, printer: &Printer, params: DidSaveTextDocumentParams) {
         let _ = printer;
         let _ = params;
@@ -234,7 +234,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// The document's truth now exists where the document's URI points to (e.g. if the document's
     /// URI is a file URI, the truth now exists on disk).
     ///
-    /// [`textDocument/didClose`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_didClose
+    /// [`textDocument/didClose`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_didClose
     fn did_close(&self, printer: &Printer, params: DidCloseTextDocumentParams) {
         let _ = printer;
         let _ = params;
@@ -247,7 +247,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// for the completion item resolve request (`completionItem/resolve`). This request is sent
     /// when a completion item is selected in the user interface.
     ///
-    /// [`textDocument/completion`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_completion
+    /// [`textDocument/completion`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_completion
     fn completion(&self, params: CompletionParams) -> Self::CompletionFuture;
 
     /// The [`textDocument/hover`] request asks the server for hover information at a given text
@@ -256,7 +256,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// Such hover information typically includes type signature information and inline
     /// documentation for the symbol at the given text document position.
     ///
-    /// [`textDocument/hover`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_hover
+    /// [`textDocument/hover`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_hover
     fn hover(&self, params: TextDocumentPositionParams) -> Self::HoverFuture;
 
     /// The [`textDocument/documentHighlight`] request is sent from the client to the server to
@@ -268,7 +268,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// This request differs slightly from `textDocument/references` in that this one is allowed to
     /// be more fuzzy.
     ///
-    /// [`textDocument/documentHighlight`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_documentHighlight
+    /// [`textDocument/documentHighlight`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_documentHighlight
     fn document_highlight(&self, params: TextDocumentPositionParams) -> Self::HighlightFuture;
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -31,14 +31,14 @@ impl Error for ExitedError {}
 
 /// Future which never resolves until the [`exit`] notification is received.
 ///
-/// [`exit`]: https://microsoft.github.io/language-server-protocol/specification#exit
+/// [`exit`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#exit
 #[derive(Clone, Debug)]
 pub struct ExitReceiver(Shared<oneshot::Receiver<()>>);
 
 impl ExitReceiver {
     /// Drives the future to completion, only canceling if the [`exit`] notification is received.
     ///
-    /// [`exit`]: https://microsoft.github.io/language-server-protocol/specification#exit
+    /// [`exit`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#exit
     pub fn run_until_exit<F>(self, future: F) -> impl Future<Item = (), Error = ()> + Send
     where
         F: Future<Item = (), Error = ()> + Send,
@@ -122,7 +122,7 @@ impl LspService {
 
     /// Returns a close handle which signals when the [`exit`] notification has been received.
     ///
-    /// [`exit`]: https://microsoft.github.io/language-server-protocol/specification#exit
+    /// [`exit`]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#exit
     pub fn close_handle(&self) -> ExitReceiver {
         self.exit_rx.clone()
     }


### PR DESCRIPTION
### Changed

* Bump crate version to 0.4.0.
* Update `CHANGELOG.md`.

### Fixed

* Update old links to upstream LSP specification to point to new URLs.