### PR TITLE
Update some Cargo dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,18 +15,18 @@ keywords = ["language-server", "lsp", "tower"]
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.28"
-jsonrpc-core = "14.0"
-jsonrpc-derive = "14.0"
-log = "0.4.7"
+jsonrpc-core = "14.0.5"
+jsonrpc-derive = "14.0.5"
+log = "0.4.8"
 lsp-types = "0.61.0"
 nom = "5.0.1"
-serde = { version = "1.0.99", features = ["derive"] }
+serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1.0.40"
 tokio-codec = "0.1.1"
-tokio-executor = "0.1.8"
+tokio-executor = "0.1.9"
 tokio-io = "0.1.12"
 tower-service = "0.2.0"
 
 [dev-dependencies]
-env_logger = "0.7.0"
+env_logger = "0.7.1"
 tokio = "0.1.22"


### PR DESCRIPTION
### Changed

* Update `jsonrpc-core` dependency from version 14.0 to 14.0.5.
* Update `jsonrpc-derive` dependency from version 14.0 to 14.0.5.
* Update `log` dependency from version 0.4.7 to 0.4.8.
* Update `serde` dependency from version 1.0.99 to 1.0.103.
* Update `tokio-executor` dependency from version 0.1.8 to 0.1.9.
* Update `env_logger` dependency from version 0.7.0 to 0.7.1.