### PR TITLE
Prepare release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.5.0] - 2019-12-12
+
+### Added
+
+* Add support for Language Server Protocol 3.15.
+
+### Changed
+
+* Update `lsp-types` crate from 0.61.0 to 0.63.1.
+
 ## [0.4.1] - 2019-12-09
 
 ### Changed
@@ -122,7 +132,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * `textDocument/hover`
   * `textDocument/documentHighlight`
 
-[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.3.0...v0.3.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 edition = "2018"
 description = "Language Server Protocol implementation based on Tower"


### PR DESCRIPTION
### Changed

* Bump crate version to 0.5.0.
* Update `CHANGELOG.md`.