### PR TITLE
Add goto declaration, definition, typeDefinition requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Implement support for the following client-to-server messages:
+  * `textDocument/declaration`
+  * `textDocument/definition`
+  * `textDocument/typeDefinition`
+
 ## [0.5.0] - 2019-12-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ consists of three parts:
 use futures::future;
 use jsonrpc_core::{BoxFuture, Result};
 use serde_json::Value;
+use tower_lsp::lsp_types::request::GotoDefinitionResponse;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{LanguageServer, LspService, Printer, Server};
 
@@ -54,6 +55,9 @@ impl LanguageServer for Backend {
     type ExecuteFuture = BoxFuture<Option<Value>>;
     type CompletionFuture = BoxFuture<Option<CompletionResponse>>;
     type HoverFuture = BoxFuture<Option<Hover>>;
+    type DeclarationFuture = BoxFuture<Option<GotoDefinitionResponse>>;
+    type DefinitionFuture = BoxFuture<Option<GotoDefinitionResponse>>;
+    type TypeDefinitionFuture = BoxFuture<Option<GotoDefinitionResponse>>;
     type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
 
     fn initialize(&self, _: &Printer, _: InitializeParams) -> Result<InitializeResult> {
@@ -77,6 +81,18 @@ impl LanguageServer for Backend {
     }
 
     fn completion(&self, _: CompletionParams) -> Self::CompletionFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn goto_declaration(&self, _: TextDocumentPositionParams) -> Self::DeclarationFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn goto_definition(&self, _: TextDocumentPositionParams) -> Self::DefinitionFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn goto_type_definition(&self, _: TextDocumentPositionParams) -> Self::TypeDefinitionFuture {
         Box::new(future::ok(None))
     }
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,6 +1,7 @@
 use futures::future;
 use jsonrpc_core::{BoxFuture, Result};
 use serde_json::Value;
+use tower_lsp::lsp_types::request::GotoDefinitionResponse;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{LanguageServer, LspService, Printer, Server};
 
@@ -13,6 +14,9 @@ impl LanguageServer for Backend {
     type ExecuteFuture = BoxFuture<Option<Value>>;
     type CompletionFuture = BoxFuture<Option<CompletionResponse>>;
     type HoverFuture = BoxFuture<Option<Hover>>;
+    type DeclarationFuture = BoxFuture<Option<GotoDefinitionResponse>>;
+    type DefinitionFuture = BoxFuture<Option<GotoDefinitionResponse>>;
+    type TypeDefinitionFuture = BoxFuture<Option<GotoDefinitionResponse>>;
     type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
 
     fn initialize(&self, _: &Printer, _: InitializeParams) -> Result<InitializeResult> {
@@ -103,6 +107,18 @@ impl LanguageServer for Backend {
     }
 
     fn hover(&self, _: TextDocumentPositionParams) -> Self::HoverFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn goto_declaration(&self, _: TextDocumentPositionParams) -> Self::DeclarationFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn goto_definition(&self, _: TextDocumentPositionParams) -> Self::DefinitionFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn goto_type_definition(&self, _: TextDocumentPositionParams) -> Self::TypeDefinitionFuture {
         Box::new(future::ok(None))
     }
 

--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -87,6 +87,15 @@ pub trait LanguageServerCore {
     #[rpc(name = "textDocument/hover", raw_params)]
     fn hover(&self, params: Params) -> BoxFuture<Option<Hover>>;
 
+    #[rpc(name = "textDocument/declaration", raw_params)]
+    fn goto_declaration(&self, params: Params) -> BoxFuture<Option<GotoDefinitionResponse>>;
+
+    #[rpc(name = "textDocument/definition", raw_params)]
+    fn goto_definition(&self, params: Params) -> BoxFuture<Option<GotoDefinitionResponse>>;
+
+    #[rpc(name = "textDocument/typeDefinition", raw_params)]
+    fn goto_type_definition(&self, params: Params) -> BoxFuture<Option<GotoDefinitionResponse>>;
+
     #[rpc(name = "textDocument/documentHighlight", raw_params)]
     fn document_highlight(&self, params: Params) -> BoxFuture<Option<Vec<DocumentHighlight>>>;
 }
@@ -233,6 +242,27 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
 
     fn hover(&self, params: Params) -> BoxFuture<Option<Hover>> {
         self.delegate_request::<HoverRequest, _>(params, |p| Box::new(self.server.hover(p)))
+    }
+
+    fn goto_declaration(&self, params: Params) -> BoxFuture<Option<GotoDefinitionResponse>> {
+        self.delegate_request::<GotoDeclaration, _>(params, |p| {
+            Box::new(self.server.goto_declaration(p))
+        })
+    }
+
+    fn goto_definition(&self, params: Params) -> BoxFuture<Option<GotoDefinitionResponse>> {
+        self.delegate_request::<GotoDefinition, _>(params, |p| {
+            Box::new(self.server.goto_definition(p))
+        })
+    }
+
+    fn goto_type_definition(
+        &self,
+        params: Params,
+    ) -> BoxFuture<Option<GotoTypeDefinitionResponse>> {
+        self.delegate_request::<GotoTypeDefinition, _>(params, |p| {
+            Box::new(self.server.goto_type_definition(p))
+        })
     }
 
     fn document_highlight(&self, params: Params) -> BoxFuture<Option<Vec<DocumentHighlight>>> {

--- a/src/service.rs
+++ b/src/service.rs
@@ -172,6 +172,7 @@ impl Service<Incoming> for LspService {
 #[cfg(test)]
 mod tests {
     use jsonrpc_core::{BoxFuture, Result};
+    use lsp_types::request::GotoDefinitionResponse;
     use lsp_types::*;
     use serde_json::Value;
 
@@ -186,8 +187,11 @@ mod tests {
         type SymbolFuture = BoxFuture<Option<Vec<SymbolInformation>>>;
         type ExecuteFuture = BoxFuture<Option<Value>>;
         type CompletionFuture = BoxFuture<Option<CompletionResponse>>;
-        type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
         type HoverFuture = BoxFuture<Option<Hover>>;
+        type DeclarationFuture = BoxFuture<Option<GotoDefinitionResponse>>;
+        type DefinitionFuture = BoxFuture<Option<GotoDefinitionResponse>>;
+        type TypeDefinitionFuture = BoxFuture<Option<GotoDefinitionResponse>>;
+        type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
 
         fn initialize(&self, _: &Printer, _: InitializeParams) -> Result<InitializeResult> {
             Ok(InitializeResult::default())
@@ -210,6 +214,21 @@ mod tests {
         }
 
         fn hover(&self, _: TextDocumentPositionParams) -> Self::HoverFuture {
+            Box::new(future::ok(None))
+        }
+
+        fn goto_declaration(&self, _: TextDocumentPositionParams) -> Self::DeclarationFuture {
+            Box::new(future::ok(None))
+        }
+
+        fn goto_definition(&self, _: TextDocumentPositionParams) -> Self::DefinitionFuture {
+            Box::new(future::ok(None))
+        }
+
+        fn goto_type_definition(
+            &self,
+            _: TextDocumentPositionParams,
+        ) -> Self::TypeDefinitionFuture {
             Box::new(future::ok(None))
         }
 


### PR DESCRIPTION
### Added

* Implement support for `textDocument/declaration` request.
* Implement support for `textDocument/definition` request.
* Implement support for `textDocument/typeDefinition` request.

### Changed

* Update `CHANGELOG.md`.

This pull request is one step toward resolving #10.