### PR TITLE
Prepare release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.6.0] - 2020-01-07
+
 ### Added
 
 * Implement support for the following client-to-server messages:
@@ -143,7 +145,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * `textDocument/hover`
   * `textDocument/documentHighlight`
 
-[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.3.1...v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 edition = "2018"
 description = "Language Server Protocol implementation based on Tower"

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Eyal Kalderon
+Copyright (c) 2020 Eyal Kalderon
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
### Changed

* Bump crate version to 0.6.0.
* Update `CHANGELOG.md`.
* Update copyright year in `LICENSE-MIT`.