### PR TITLE
Add disclaimer about futures 0.1 to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ consists of three parts:
 * A `Server` which spawns the `LspService` and processes requests and responses
   over stdin and stdout.
 
+_NOTE: This library currently relies on `futures` 0.1 and is not async/await
+ready. Support for `std::future::Future` and async/await is tracked in [#58]._
+
+[#58]: https://github.com/ebkalderon/tower-lsp/issues/58
+
 ## Example
 
 ```rust


### PR DESCRIPTION
### Changed

* Add disclaimer about this library's reliance on `futures` 0.1 to `README.md`.

We must be up-front with potential users that this library is not yet ready for `std::future::Future` and async/await, and we also link to issue #58 for tracking support for it.