### PR TITLE
Implement custom notification functionality for printer

### DIFF
--- a/examples/custom_notification.rs
+++ b/examples/custom_notification.rs
@@ -40,12 +40,12 @@ impl LanguageServer for Backend {
     type ExecuteFuture = BoxFuture<Option<Value>>;
     type CompletionFuture = BoxFuture<Option<CompletionResponse>>;
     type HoverFuture = BoxFuture<Option<Hover>>;
+    type SignatureHelpFuture = BoxFuture<Option<SignatureHelp>>;
     type DeclarationFuture = BoxFuture<Option<GotoDefinitionResponse>>;
     type DefinitionFuture = BoxFuture<Option<GotoDefinitionResponse>>;
     type TypeDefinitionFuture = BoxFuture<Option<GotoDefinitionResponse>>;
+    type ImplementationFuture = BoxFuture<Option<GotoImplementationResponse>>;
     type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
-    type SignatureHelpFuture = BoxFuture<Option<SignatureHelp>>;
-    type GotoImplementationFuture = BoxFuture<Option<GotoImplementationResponse>>;
 
     fn initialize(&self, _: &Printer, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {
@@ -153,6 +153,10 @@ impl LanguageServer for Backend {
         Box::new(future::ok(None))
     }
 
+    fn signature_help(&self, _: TextDocumentPositionParams) -> Self::SignatureHelpFuture {
+        Box::new(future::ok(None))
+    }
+
     fn goto_declaration(&self, _: TextDocumentPositionParams) -> Self::DeclarationFuture {
         Box::new(future::ok(None))
     }
@@ -165,15 +169,11 @@ impl LanguageServer for Backend {
         Box::new(future::ok(None))
     }
 
+    fn goto_implementation(&self, _: TextDocumentPositionParams) -> Self::ImplementationFuture {
+        Box::new(future::ok(None))
+    }
+
     fn document_highlight(&self, _: TextDocumentPositionParams) -> Self::HighlightFuture {
-        Box::new(future::ok(None))
-    }
-
-    fn signature_help(&self, _: TextDocumentPositionParams) -> Self::SignatureHelpFuture {
-        Box::new(future::ok(None))
-    }
-
-    fn goto_implementation(&self, _: TextDocumentPositionParams) -> Self::GotoImplementationFuture {
         Box::new(future::ok(None))
     }
 }

--- a/examples/custom_notification.rs
+++ b/examples/custom_notification.rs
@@ -87,28 +87,12 @@ impl LanguageServer for Backend {
         })
     }
 
-    fn initialized(&self, printer: &Printer, _: InitializedParams) {
-        printer.log_message(MessageType::Info, "server initialized!");
-    }
-
     fn shutdown(&self) -> Self::ShutdownFuture {
         Box::new(future::ok(()))
     }
 
     fn symbol(&self, _: WorkspaceSymbolParams) -> Self::SymbolFuture {
         Box::new(future::ok(None))
-    }
-
-    fn did_change_workspace_folders(&self, printer: &Printer, _: DidChangeWorkspaceFoldersParams) {
-        printer.log_message(MessageType::Info, "workspace folders changed!");
-    }
-
-    fn did_change_configuration(&self, printer: &Printer, _: DidChangeConfigurationParams) {
-        printer.log_message(MessageType::Info, "configuration changed!");
-    }
-
-    fn did_change_watched_files(&self, printer: &Printer, _: DidChangeWatchedFilesParams) {
-        printer.log_message(MessageType::Info, "watched files have changed!");
     }
 
     fn execute_command(
@@ -127,22 +111,6 @@ impl LanguageServer for Backend {
         );
         printer.apply_edit(WorkspaceEdit::default());
         Box::new(future::ok(None))
-    }
-
-    fn did_open(&self, printer: &Printer, _: DidOpenTextDocumentParams) {
-        printer.log_message(MessageType::Info, "file opened!");
-    }
-
-    fn did_change(&self, printer: &Printer, _: DidChangeTextDocumentParams) {
-        printer.log_message(MessageType::Info, "file changed!");
-    }
-
-    fn did_save(&self, printer: &Printer, _: DidSaveTextDocumentParams) {
-        printer.log_message(MessageType::Info, "file saved!");
-    }
-
-    fn did_close(&self, printer: &Printer, _: DidCloseTextDocumentParams) {
-        printer.log_message(MessageType::Info, "file closed!");
     }
 
     fn completion(&self, _: CompletionParams) -> Self::CompletionFuture {

--- a/examples/custom_notification.rs
+++ b/examples/custom_notification.rs
@@ -1,0 +1,185 @@
+use futures::future;
+use jsonrpc_core::{BoxFuture, Result};
+use serde_json::Value;
+use tower_lsp::lsp_types::request::GotoDefinitionResponse;
+use tower_lsp::lsp_types::*;
+use tower_lsp::{LanguageServer, LspService, Printer, Server};
+use lsp_types::request::GotoImplementationResponse;
+use lsp_types::notification::Notification;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+struct CustomNotificationParams {
+    title: String,
+    message: String
+}
+
+impl CustomNotificationParams {
+    fn new(title: impl Into<String>, message: impl Into<String>) -> Self {
+        CustomNotificationParams {
+            title: title.into(),
+            message: message.into()
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CustomNotification {}
+
+impl Notification for CustomNotification {
+    type Params = CustomNotificationParams;
+    const METHOD: &'static str = "custom/notification";
+}
+
+#[derive(Debug, Default)]
+struct Backend;
+
+impl LanguageServer for Backend {
+    type ShutdownFuture = BoxFuture<()>;
+    type SymbolFuture = BoxFuture<Option<Vec<SymbolInformation>>>;
+    type ExecuteFuture = BoxFuture<Option<Value>>;
+    type CompletionFuture = BoxFuture<Option<CompletionResponse>>;
+    type HoverFuture = BoxFuture<Option<Hover>>;
+    type DeclarationFuture = BoxFuture<Option<GotoDefinitionResponse>>;
+    type DefinitionFuture = BoxFuture<Option<GotoDefinitionResponse>>;
+    type TypeDefinitionFuture = BoxFuture<Option<GotoDefinitionResponse>>;
+    type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
+    type SignatureHelpFuture = BoxFuture<Option<SignatureHelp>>;
+    type GotoImplementationFuture = BoxFuture<Option<GotoImplementationResponse>>;
+
+
+    fn initialize(&self, _: &Printer, _: InitializeParams) -> Result<InitializeResult> {
+        Ok(InitializeResult {
+            server_info: None,
+            capabilities: ServerCapabilities {
+                text_document_sync: Some(TextDocumentSyncCapability::Kind(
+                    TextDocumentSyncKind::Incremental,
+                )),
+                hover_provider: Some(true),
+                completion_provider: Some(CompletionOptions {
+                    resolve_provider: Some(false),
+                    trigger_characters: Some(vec![".".to_string()]),
+                    work_done_progress_options: Default::default(),
+                }),
+                signature_help_provider: Some(SignatureHelpOptions {
+                    trigger_characters: None,
+                    retrigger_characters: None,
+                    work_done_progress_options: Default::default(),
+                }),
+                document_highlight_provider: Some(true),
+                workspace_symbol_provider: Some(true),
+                execute_command_provider: Some(ExecuteCommandOptions {
+                    commands: vec!["dummy.do_something".to_string(), "custom.notification".to_string()],
+                    work_done_progress_options: Default::default(),
+                }),
+                workspace: Some(WorkspaceCapability {
+                    workspace_folders: Some(WorkspaceFolderCapability {
+                        supported: Some(true),
+                        change_notifications: Some(
+                            WorkspaceFolderCapabilityChangeNotifications::Bool(true),
+                        ),
+                    }),
+                }),
+                ..ServerCapabilities::default()
+            },
+        })
+    }
+
+    fn initialized(&self, printer: &Printer, _: InitializedParams) {
+        printer.log_message(MessageType::Info, "server initialized!");
+    }
+
+    fn shutdown(&self) -> Self::ShutdownFuture {
+        Box::new(future::ok(()))
+    }
+
+    fn symbol(&self, _: WorkspaceSymbolParams) -> Self::SymbolFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn did_change_workspace_folders(&self, printer: &Printer, _: DidChangeWorkspaceFoldersParams) {
+        printer.log_message(MessageType::Info, "workspace folders changed!");
+    }
+
+    fn did_change_configuration(&self, printer: &Printer, _: DidChangeConfigurationParams) {
+        printer.log_message(MessageType::Info, "configuration changed!");
+    }
+
+    fn did_change_watched_files(&self, printer: &Printer, _: DidChangeWatchedFilesParams) {
+        printer.log_message(MessageType::Info, "watched files have changed!");
+    }
+
+    fn execute_command(&self, printer: &Printer, params: ExecuteCommandParams) -> Self::ExecuteFuture {
+        if &params.command == "custom.notification" {
+            printer.send_notification::<CustomNotification>(
+                CustomNotificationParams::new("Hello", "Message")
+            );
+        }
+        printer.log_message(MessageType::Info, format!("command executed!: {:?}", params));
+        printer.apply_edit(WorkspaceEdit::default());
+        Box::new(future::ok(None))
+    }
+
+    fn did_open(&self, printer: &Printer, _: DidOpenTextDocumentParams) {
+        printer.log_message(MessageType::Info, "file opened!");
+    }
+
+    fn did_change(&self, printer: &Printer, _: DidChangeTextDocumentParams) {
+        printer.log_message(MessageType::Info, "file changed!");
+    }
+
+    fn did_save(&self, printer: &Printer, _: DidSaveTextDocumentParams) {
+        printer.log_message(MessageType::Info, "file saved!");
+    }
+
+    fn did_close(&self, printer: &Printer, _: DidCloseTextDocumentParams) {
+        printer.log_message(MessageType::Info, "file closed!");
+    }
+
+    fn completion(&self, _: CompletionParams) -> Self::CompletionFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn hover(&self, _: TextDocumentPositionParams) -> Self::HoverFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn goto_declaration(&self, _: TextDocumentPositionParams) -> Self::DeclarationFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn goto_definition(&self, _: TextDocumentPositionParams) -> Self::DefinitionFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn goto_type_definition(&self, _: TextDocumentPositionParams) -> Self::TypeDefinitionFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn document_highlight(&self, _: TextDocumentPositionParams) -> Self::HighlightFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn signature_help(&self, _: TextDocumentPositionParams) -> Self::SignatureHelpFuture {
+        Box::new(future::ok(None))
+    }
+
+    fn goto_implementation(&self, _: TextDocumentPositionParams) -> Self::GotoImplementationFuture {
+        Box::new(future::ok(None))
+    }
+}
+
+fn main() {
+    env_logger::init();
+
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+
+    let (service, messages) = LspService::new(Backend::default());
+    let handle = service.close_handle();
+    let server = Server::new(stdin, stdout)
+        .interleave(messages)
+        .serve(service);
+
+    tokio::run(handle.run_until_exit(server));
+}

--- a/src/delegate/printer.rs
+++ b/src/delegate/printer.rs
@@ -133,7 +133,7 @@ impl Printer {
     pub fn send_notification<N>(&self, params: N::Params)
     where
         N: Notification,
-        N::Params: Serialize
+        N::Params: Serialize,
     {
         self.send_message_initialized(make_notification::<N>(params));
     }

--- a/src/delegate/printer.rs
+++ b/src/delegate/printer.rs
@@ -129,6 +129,15 @@ impl Printer {
         ));
     }
 
+    /// Send a custom notification to the client
+    pub fn send_notification<N>(&self, params: N::Params)
+    where
+        N: Notification,
+        N::Params: Serialize
+    {
+        self.send_message_initialized(make_notification::<N>(params));
+    }
+
     fn send_message(&self, message: String) {
         tokio_executor::spawn(
             self.buffer


### PR DESCRIPTION
With this the server should be able to send custom notifications to the client in requests that have the `printer` as parameter. It contains the same changes as #98 and the notification implementation (I think it is better to separate these pull requests).

`custom_notification.rs` in the examples folder shows a possible usage. Here's the client side code example, I wasn't really sure where to put it...

```typescript

interface CustomNotificationParams {
	title: string
	message: string
}

let languageClient = new client.LanguageClient(id, name, serverOptions, clientOptions);
languageClient.onReady().then(() => {
    languageClient.onNotification("custom/notification", (params: CustomNotificationParams) => {
        console.log(`${params.title} ${params.message}`);
    });
});
```