### PR TITLE
Convert to std::future and async/await

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust-version: [1.36.0, beta, nightly]
+        rust-version: [1.39.0, beta, nightly]
         include:
         - rust-version: nightly
           continue-on-error: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,4 @@ tower-service = "0.3.0"
 [dev-dependencies]
 env_logger = "0.7.1"
 tokio = { version = "0.2.11", features = ["io-std", "macros", "test-util"] }
-tokio-test = "0.2.0"
 tower-test = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,21 +13,21 @@ categories = ["asynchronous"]
 keywords = ["language-server", "lsp", "tower"]
 
 [dependencies]
-async-trait = "0.1.24"
-bytes = "0.5.0"
-futures = { version = "0.3.2", features = ["compat"] }
-jsonrpc-core = "14.0.5"
-jsonrpc-derive = "14.0.5"
-log = "0.4.8"
-lsp-types = "0.68.0"
-nom = "5.0.1"
-serde = { version = "1.0.103", features = ["derive"] }
-serde_json = "1.0.40"
-tokio = { version = "0.2.11", features = ["rt-core"] }
-tokio-util = { version = "0.2.0", features = ["codec"] }
-tower-service = "0.3.0"
+async-trait = "0.1"
+bytes = "0.5"
+futures = { version = "0.3", features = ["compat"] }
+jsonrpc-core = "14.0"
+jsonrpc-derive = "14.0"
+log = "0.4"
+lsp-types = "0.68"
+nom = "5.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "0.2", features = ["rt-core"] }
+tokio-util = { version = "0.2", features = ["codec"] }
+tower-service = "0.3"
 
 [dev-dependencies]
-env_logger = "0.7.1"
-tokio = { version = "0.2.11", features = ["io-std", "macros", "test-util"] }
-tower-test = "0.3.0"
+env_logger = "0.7"
+tokio = { version = "0.2", features = ["io-std", "macros", "test-util"] }
+tower-test = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ categories = ["asynchronous"]
 keywords = ["language-server", "lsp", "tower"]
 
 [dependencies]
-bytes = "0.4.12"
-futures = "0.1.28"
+async-trait = "0.1.24"
+bytes = "0.5.0"
+futures = { version = "0.3.2", features = ["compat"] }
 jsonrpc-core = "14.0.5"
 jsonrpc-derive = "14.0.5"
 log = "0.4.8"
@@ -22,11 +23,12 @@ lsp-types = "0.68.0"
 nom = "5.0.1"
 serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1.0.40"
-tokio-codec = "0.1.1"
-tokio-executor = "0.1.9"
-tokio-io = "0.1.12"
-tower-service = "0.2.0"
+tokio = { version = "0.2.11", features = ["rt-core"] }
+tokio-util = { version = "0.2.0", features = ["codec"] }
+tower-service = "0.3.0"
 
 [dev-dependencies]
 env_logger = "0.7.1"
-tokio = "0.1.22"
+tokio = { version = "0.2.11", features = ["io-std", "macros", "test-util"] }
+tokio-test = "0.2.0"
+tower-test = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -36,35 +36,20 @@ consists of three parts:
 * A `Server` which spawns the `LspService` and processes requests and responses
   over stdin and stdout.
 
-_NOTE: This library currently relies on `futures` 0.1 and is not async/await
-ready. Support for `std::future::Future` and async/await is tracked in [#58]._
-
-[#58]: https://github.com/ebkalderon/tower-lsp/issues/58
-
 ## Example
 
 ```rust
-use futures::future;
-use jsonrpc_core::{BoxFuture, Result};
+use jsonrpc_core::Result;
 use serde_json::Value;
-use tower_lsp::lsp_types::request::GotoDefinitionResponse;
+use tower_lsp::lsp_types::request::*;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{LanguageServer, LspService, Printer, Server};
 
 #[derive(Debug, Default)]
 struct Backend;
 
+#[tower_lsp::async_trait]
 impl LanguageServer for Backend {
-    type ShutdownFuture = BoxFuture<()>;
-    type SymbolFuture = BoxFuture<Option<Vec<SymbolInformation>>>;
-    type ExecuteFuture = BoxFuture<Option<Value>>;
-    type CompletionFuture = BoxFuture<Option<CompletionResponse>>;
-    type HoverFuture = BoxFuture<Option<Hover>>;
-    type DeclarationFuture = BoxFuture<Option<GotoDefinitionResponse>>;
-    type DefinitionFuture = BoxFuture<Option<GotoDefinitionResponse>>;
-    type TypeDefinitionFuture = BoxFuture<Option<GotoDefinitionResponse>>;
-    type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
-
     fn initialize(&self, _: &Printer, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult::default())
     }
@@ -73,44 +58,53 @@ impl LanguageServer for Backend {
         printer.log_message(MessageType::Info, "server initialized!");
     }
 
-    fn shutdown(&self) -> Self::ShutdownFuture {
-        Box::new(future::ok(()))
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
     }
 
-    fn symbol(&self, _: WorkspaceSymbolParams) -> Self::SymbolFuture {
-        Box::new(future::ok(None))
+    async fn symbol(&self, _: WorkspaceSymbolParams) -> Result<Option<Vec<SymbolInformation>>> {
+        Ok(None)
     }
 
-    fn execute_command(&self, _: &Printer, _: ExecuteCommandParams) -> Self::ExecuteFuture {
-        Box::new(future::ok(None))
+    async fn execute_command(&self, _: &Printer, _: ExecuteCommandParams) -> Result<Option<Value>> {
+        Ok(None)
     }
 
-    fn completion(&self, _: CompletionParams) -> Self::CompletionFuture {
-        Box::new(future::ok(None))
+    async fn completion(&self, _: CompletionParams) -> Result<Option<CompletionResponse>> {
+        Ok(None)
     }
 
-    fn goto_declaration(&self, _: TextDocumentPositionParams) -> Self::DeclarationFuture {
-        Box::new(future::ok(None))
+    async fn hover(&self, _: TextDocumentPositionParams) -> Result<Option<Hover>> {
+        Ok(None)
     }
 
-    fn goto_definition(&self, _: TextDocumentPositionParams) -> Self::DefinitionFuture {
-        Box::new(future::ok(None))
+    async fn signature_help(&self, _: TextDocumentPositionParams) -> Result<Option<SignatureHelp>> {
+        Ok(None)
     }
 
-    fn goto_type_definition(&self, _: TextDocumentPositionParams) -> Self::TypeDefinitionFuture {
-        Box::new(future::ok(None))
+    async fn goto_declaration(&self, _: TextDocumentPositionParams) -> Result<Option<GotoDefinitionResponse>> {
+        Ok(None)
     }
 
-    fn hover(&self, _: TextDocumentPositionParams) -> Self::HoverFuture {
-        Box::new(future::ok(None))
+    async fn goto_definition(&self, _: TextDocumentPositionParams) -> Result<Option<GotoDefinitionResponse>> {
+        Ok(None)
     }
 
-    fn document_highlight(&self, _: TextDocumentPositionParams) -> Self::HighlightFuture {
-        Box::new(future::ok(None))
+    async fn goto_type_definition(&self, _: TextDocumentPositionParams) -> Result<Option<GotoDefinitionResponse>> {
+        Ok(None)
+    }
+
+    async fn goto_implementation(&self, _: TextDocumentPositionParams) -> Result<Option<GotoImplementationResponse>> {
+        Ok(None)
+    }
+
+    async fn document_highlight(&self, _: TextDocumentPositionParams) -> Result<Option<Vec<DocumentHighlight>>> {
+        Ok(None)
     }
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
@@ -120,7 +114,7 @@ fn main() {
         .interleave(messages)
         .serve(service);
 
-    tokio::run(handle.run_until_exit(server));
+    handle.run_until_exit(server).await;
 }
 ```
 

--- a/examples/custom_notification.rs
+++ b/examples/custom_notification.rs
@@ -1,12 +1,12 @@
 use jsonrpc_core::Result;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::Value;
 use tower_lsp::lsp_types::notification::Notification;
 use tower_lsp::lsp_types::request::{GotoDefinitionResponse, GotoImplementationResponse};
 use tower_lsp::lsp_types::*;
 use tower_lsp::{LanguageServer, LspService, Printer, Server};
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Serialize)]
 struct CustomNotificationParams {
     title: String,
     message: String,

--- a/examples/custom_notification.rs
+++ b/examples/custom_notification.rs
@@ -2,7 +2,7 @@ use jsonrpc_core::Result;
 use serde::Serialize;
 use serde_json::Value;
 use tower_lsp::lsp_types::notification::Notification;
-use tower_lsp::lsp_types::request::{GotoDefinitionResponse, GotoImplementationResponse};
+use tower_lsp::lsp_types::request::*;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{LanguageServer, LspService, Printer, Server};
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,6 +1,6 @@
 use jsonrpc_core::Result;
 use serde_json::Value;
-use tower_lsp::lsp_types::request::{GotoDefinitionResponse, GotoImplementationResponse};
+use tower_lsp::lsp_types::request::*;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{LanguageServer, LspService, Printer, Server};
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,5 +1,4 @@
-use futures::future;
-use jsonrpc_core::{BoxFuture, Result};
+use jsonrpc_core::Result;
 use serde_json::Value;
 use tower_lsp::lsp_types::request::{GotoDefinitionResponse, GotoImplementationResponse};
 use tower_lsp::lsp_types::*;
@@ -8,19 +7,8 @@ use tower_lsp::{LanguageServer, LspService, Printer, Server};
 #[derive(Debug, Default)]
 struct Backend;
 
+#[tower_lsp::async_trait]
 impl LanguageServer for Backend {
-    type ShutdownFuture = BoxFuture<()>;
-    type SymbolFuture = BoxFuture<Option<Vec<SymbolInformation>>>;
-    type ExecuteFuture = BoxFuture<Option<Value>>;
-    type CompletionFuture = BoxFuture<Option<CompletionResponse>>;
-    type HoverFuture = BoxFuture<Option<Hover>>;
-    type SignatureHelpFuture = BoxFuture<Option<SignatureHelp>>;
-    type DeclarationFuture = BoxFuture<Option<GotoDefinitionResponse>>;
-    type DefinitionFuture = BoxFuture<Option<GotoDefinitionResponse>>;
-    type TypeDefinitionFuture = BoxFuture<Option<GotoDefinitionResponse>>;
-    type ImplementationFuture = BoxFuture<Option<GotoImplementationResponse>>;
-    type HighlightFuture = BoxFuture<Option<Vec<DocumentHighlight>>>;
-
     fn initialize(&self, _: &Printer, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {
             server_info: None,
@@ -62,12 +50,12 @@ impl LanguageServer for Backend {
         printer.log_message(MessageType::Info, "server initialized!");
     }
 
-    fn shutdown(&self) -> Self::ShutdownFuture {
-        Box::new(future::ok(()))
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
     }
 
-    fn symbol(&self, _: WorkspaceSymbolParams) -> Self::SymbolFuture {
-        Box::new(future::ok(None))
+    async fn symbol(&self, _: WorkspaceSymbolParams) -> Result<Option<Vec<SymbolInformation>>> {
+        Ok(None)
     }
 
     fn did_change_workspace_folders(&self, printer: &Printer, _: DidChangeWorkspaceFoldersParams) {
@@ -82,10 +70,14 @@ impl LanguageServer for Backend {
         printer.log_message(MessageType::Info, "watched files have changed!");
     }
 
-    fn execute_command(&self, printer: &Printer, _: ExecuteCommandParams) -> Self::ExecuteFuture {
+    async fn execute_command(
+        &self,
+        printer: &Printer,
+        _: ExecuteCommandParams,
+    ) -> Result<Option<Value>> {
         printer.log_message(MessageType::Info, "command executed!");
         printer.apply_edit(WorkspaceEdit::default());
-        Box::new(future::ok(None))
+        Ok(None)
     }
 
     fn did_open(&self, printer: &Printer, _: DidOpenTextDocumentParams) {
@@ -104,40 +96,56 @@ impl LanguageServer for Backend {
         printer.log_message(MessageType::Info, "file closed!");
     }
 
-    fn completion(&self, _: CompletionParams) -> Self::CompletionFuture {
-        Box::new(future::ok(None))
+    async fn completion(&self, _: CompletionParams) -> Result<Option<CompletionResponse>> {
+        Ok(None)
     }
 
-    fn hover(&self, _: TextDocumentPositionParams) -> Self::HoverFuture {
-        Box::new(future::ok(None))
+    async fn hover(&self, _: TextDocumentPositionParams) -> Result<Option<Hover>> {
+        Ok(None)
     }
 
-    fn signature_help(&self, _: TextDocumentPositionParams) -> Self::SignatureHelpFuture {
-        Box::new(future::ok(None))
+    async fn signature_help(&self, _: TextDocumentPositionParams) -> Result<Option<SignatureHelp>> {
+        Ok(None)
     }
 
-    fn goto_declaration(&self, _: TextDocumentPositionParams) -> Self::DeclarationFuture {
-        Box::new(future::ok(None))
+    async fn goto_declaration(
+        &self,
+        _: TextDocumentPositionParams,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        Ok(None)
     }
 
-    fn goto_definition(&self, _: TextDocumentPositionParams) -> Self::DefinitionFuture {
-        Box::new(future::ok(None))
+    async fn goto_definition(
+        &self,
+        _: TextDocumentPositionParams,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        Ok(None)
     }
 
-    fn goto_type_definition(&self, _: TextDocumentPositionParams) -> Self::TypeDefinitionFuture {
-        Box::new(future::ok(None))
+    async fn goto_type_definition(
+        &self,
+        _: TextDocumentPositionParams,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        Ok(None)
     }
 
-    fn goto_implementation(&self, _: TextDocumentPositionParams) -> Self::ImplementationFuture {
-        Box::new(future::ok(None))
+    async fn goto_implementation(
+        &self,
+        _: TextDocumentPositionParams,
+    ) -> Result<Option<GotoImplementationResponse>> {
+        Ok(None)
     }
 
-    fn document_highlight(&self, _: TextDocumentPositionParams) -> Self::HighlightFuture {
-        Box::new(future::ok(None))
+    async fn document_highlight(
+        &self,
+        _: TextDocumentPositionParams,
+    ) -> Result<Option<Vec<DocumentHighlight>>> {
+        Ok(None)
     }
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     env_logger::init();
 
     let stdin = tokio::io::stdin();
@@ -149,5 +157,5 @@ fn main() {
         .interleave(messages)
         .serve(service);
 
-    tokio::run(handle.run_until_exit(server));
+    handle.run_until_exit(server).await;
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -5,7 +5,8 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::io::{Error as IoError, Write};
 use std::str::{self, Utf8Error};
 
-use bytes::{BufMut, BytesMut};
+use bytes::buf::ext::BufMutExt;
+use bytes::{Buf, BytesMut};
 use nom::branch::alt;
 use nom::bytes::streaming::{is_not, tag};
 use nom::character::streaming::{char, crlf, digit1, space0};
@@ -14,7 +15,7 @@ use nom::error::ErrorKind;
 use nom::multi::length_data;
 use nom::sequence::{delimited, terminated, tuple};
 use nom::{Err, IResult, Needed};
-use tokio_codec::{Decoder, Encoder};
+use tokio_util::codec::{Decoder, Encoder};
 
 /// Errors that can occur when processing an LSP request.
 #[derive(Debug)]
@@ -155,9 +156,9 @@ mod tests {
         let mut codec = LanguageServerCodec::default();
         let mut buffer = BytesMut::new();
         codec.encode(decoded.clone(), &mut buffer).unwrap();
-        assert_eq!(buffer, BytesMut::from(encoded.clone()));
+        assert_eq!(buffer, BytesMut::from(encoded.as_str()));
 
-        let mut buffer = BytesMut::from(encoded);
+        let mut buffer = BytesMut::from(encoded.as_str());
         let message = codec.decode(&mut buffer).unwrap();
         assert_eq!(message, Some(decoded));
     }
@@ -178,7 +179,7 @@ mod tests {
         let encoded = format!("{}\r\n{}\r\n\r\n{}", content_len, content_type, decoded);
 
         let mut codec = LanguageServerCodec::default();
-        let mut buffer = BytesMut::from(encoded);
+        let mut buffer = BytesMut::from(encoded.as_str());
         let message = codec.decode(&mut buffer).unwrap();
         assert_eq!(message, Some(decoded));
     }

--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -112,9 +112,9 @@ pub trait LanguageServerCore {
 /// Wraps the language server backend and provides a `Printer` for sending notifications.
 #[derive(Debug)]
 pub struct Delegate<T> {
-    // FIXME: Remove `Arc` from `server` and `printer` once we switch to `jsonrpsee`.
-    // These are currently necessary to resolve lifetime interaction issues between `async-trait`,
-    // `jsonrpc-core`, and `.compat()`.
+    // FIXME: Investigate whether `Arc` from `server` and `printer` can be removed once we switch
+    // to `jsonrpsee`. These are currently necessary to resolve lifetime interaction issues between
+    // `async-trait`, `jsonrpc-core`, and `.compat()`.
     //
     // https://github.com/ebkalderon/tower-lsp/issues/58
     server: Arc<T>,

--- a/src/delegate/printer.rs
+++ b/src/delegate/printer.rs
@@ -129,7 +129,7 @@ impl Printer {
         ));
     }
 
-    /// Send a custom notification to the client
+    /// Sends a custom notification to the client.
     pub fn send_notification<N>(&self, params: N::Params)
     where
         N: Notification,

--- a/src/service.rs
+++ b/src/service.rs
@@ -180,7 +180,6 @@ mod tests {
     use lsp_types::request::{GotoDefinitionResponse, GotoImplementationResponse};
     use lsp_types::*;
     use serde_json::Value;
-    use tokio_test::{assert_pending, assert_ready_ok};
     use tower_test::mock::Spawn;
 
     use super::*;
@@ -268,14 +267,14 @@ mod tests {
         let mut service = Spawn::new(service);
 
         let initialized: Incoming = r#"{"jsonrpc":"2.0","method":"initialized"}"#.parse().unwrap();
-        assert_ready_ok!(service.poll_ready());
+        assert_eq!(service.poll_ready(), Poll::Ready(Ok(())));
         assert_eq!(service.call(initialized.clone()).await, Ok("".to_owned()));
 
         let exit: Incoming = r#"{"jsonrpc":"2.0","method":"exit"}"#.parse().unwrap();
-        assert_ready_ok!(service.poll_ready());
+        assert_eq!(service.poll_ready(), Poll::Ready(Ok(())));
         assert_eq!(service.call(exit).await, Ok("".to_owned()));
 
-        assert_pending!(service.poll_ready());
+        assert_eq!(service.poll_ready(), Poll::Pending);
         assert_eq!(service.call(initialized).await, Err(ExitedError));
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -71,7 +71,7 @@ impl Future for ExitReceiver {
 /// This implements [`tower_service::Service`] in order to remain independent from the underlying
 /// transport and to facilitate further abstraction with middleware.
 ///
-/// [`tower_service::Service`]: https://docs.rs/tower-service/0.2.0/tower_service/trait.Service.html
+/// [`tower_service::Service`]: https://docs.rs/tower-service/0.3.0/tower_service/trait.Service.html
 #[derive(Debug)]
 pub struct LspService {
     handler: IoHandler,

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -27,7 +27,7 @@ pub struct Server<I, O, S = Nothing> {
 impl<I, O> Server<I, O, Nothing>
 where
     I: AsyncRead + Send + Unpin,
-    O: AsyncWrite + Send + Unpin + 'static,
+    O: AsyncWrite + Send + 'static,
 {
     /// Creates a new `Server` with the given `stdin` and `stdout` handles.
     pub fn new(stdin: I, stdout: O) -> Self {
@@ -42,7 +42,7 @@ where
 impl<I, O, S> Server<I, O, S>
 where
     I: AsyncRead + Send + Unpin,
-    O: AsyncWrite + Send + Unpin + 'static,
+    O: AsyncWrite + Send + 'static,
     S: Stream<Item = String> + Send + 'static,
 {
     /// Interleaves the given stream of messages into `stdout` together with the responses.


### PR DESCRIPTION
### Added

* Re-export [`async_trait::async_trait`](https://github.com/dtolnay/async-trait) at the root for convenience.

### Changed

* Convert to `std::future::Future` and async/await (use new `futures`, `tokio`, `tower-service`).
* Update minimum supported Rust version in CI to 1.39.0.
* Add `Unpin` bound to `stdout` parameter in `Server`.
* Update `README.md`, use glob imports in examples.
* Remove unnecessary `Deserialize` derive in example.
* Drop patch versions from dependencies in `Cargo.toml`.

### Fixed

* Improve docs consistency for `Printer::send_notification()`.

### Removed

* Remove `'static` bound for `stdin` parameter in `Server`.

This closes #58, closes #64, closes #90, closes #91, closes #96, and closes #97.