### PR TITLE
Upgrade lsp-types from 0.68 to 0.70

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ futures = { version = "0.3", features = ["compat"] }
 jsonrpc-core = "14.0"
 jsonrpc-derive = "14.0"
 log = "0.4"
-lsp-types = "0.68"
+lsp-types = "0.70"
 nom = "5.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
### Changed

* Upgrade `lsp-types` dependency from 0.68 to 0.70.

Since https://github.com/brendanzab/codespan/issues/163 has been resolved, it's now safe to upgrade to latest version of `lsp-types` which is now compatible with the latest version of `codespan-lsp`.

Closes #75.