### PR TITLE
Reduce future boxing boilerplate in Delegate

### DIFF
--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -2,6 +2,7 @@
 
 pub use self::printer::Printer;
 
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -164,25 +165,27 @@ impl<T: LanguageServer> Delegate<T> {
         }
     }
 
-    fn delegate_request<R, F>(&self, params: Params, delegate: F) -> BoxFuture<R::Result>
+    fn delegate_request<R, F, F2>(&self, params: Params, delegate: F) -> BoxFuture<R::Result>
     where
         R: Request,
-        R::Params: DeserializeOwned,
+        R::Params: DeserializeOwned + Send,
         R::Result: Send + 'static,
-        F: FnOnce(R::Params) -> BoxFuture<R::Result>,
+        F: FnOnce(R::Params) -> F2 + Send + 'static,
+        F2: Future<Output = RpcResult<R::Result>> + Send + 'static,
     {
         trace!("received `{}` request: {:?}", R::METHOD, params);
         if self.initialized.load(Ordering::SeqCst) {
-            match params.parse() {
-                Ok(params) => delegate(params),
-                Err(err) => Box::new(
-                    future::err(Error::invalid_params_with_details(
+            let fut = async move {
+                match params.parse() {
+                    Ok(params) => delegate(params).await,
+                    Err(err) => Err(Error::invalid_params_with_details(
                         "invalid parameters",
                         err,
-                    ))
-                    .compat(),
-                ),
-            }
+                    )),
+                }
+            };
+
+            Box::new(fut.boxed().compat())
         } else {
             Box::new(future::err(not_initialized_error()).compat())
         }
@@ -234,20 +237,16 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
 
     fn symbol(&self, params: Params) -> BoxFuture<Option<Vec<SymbolInformation>>> {
         let server = self.server.clone();
-        self.delegate_request::<WorkspaceSymbol, _>(params, move |p| {
-            Box::new(async move { server.symbol(p).await }.boxed().compat())
+        self.delegate_request::<WorkspaceSymbol, _, _>(params, move |p| async move {
+            server.symbol(p).await
         })
     }
 
     fn execute_command(&self, params: Params) -> BoxFuture<Option<Value>> {
         let server = self.server.clone();
         let printer = self.printer.clone();
-        self.delegate_request::<ExecuteCommand, _>(params, move |p| {
-            Box::new(
-                async move { server.execute_command(&printer, p).await }
-                    .boxed()
-                    .compat(),
-            )
+        self.delegate_request::<ExecuteCommand, _, _>(params, move |p| async move {
+            server.execute_command(&printer, p).await
         })
     }
 
@@ -277,59 +276,43 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
 
     fn completion(&self, params: Params) -> BoxFuture<Option<CompletionResponse>> {
         let server = self.server.clone();
-        self.delegate_request::<Completion, _>(params, move |p| {
-            Box::new(async move { server.completion(p).await }.boxed().compat())
+        self.delegate_request::<Completion, _, _>(params, move |p| async move {
+            server.completion(p).await
         })
     }
 
     fn completion_resolve(&self, params: Params) -> BoxFuture<CompletionItem> {
         let server = self.server.clone();
-        self.delegate_request::<ResolveCompletionItem, _>(params, move |p| {
-            Box::new(
-                async move { server.completion_resolve(p).await }
-                    .boxed()
-                    .compat(),
-            )
+        self.delegate_request::<ResolveCompletionItem, _, _>(params, move |p| async move {
+            server.completion_resolve(p).await
         })
     }
 
     fn hover(&self, params: Params) -> BoxFuture<Option<Hover>> {
         let server = self.server.clone();
-        self.delegate_request::<HoverRequest, _>(params, move |p| {
-            Box::new(async move { server.hover(p).await }.boxed().compat())
+        self.delegate_request::<HoverRequest, _, _>(params, move |p| async move {
+            server.hover(p).await
         })
     }
 
     fn signature_help(&self, params: Params) -> BoxFuture<Option<SignatureHelp>> {
         let server = self.server.clone();
-        self.delegate_request::<SignatureHelpRequest, _>(params, move |p| {
-            Box::new(
-                async move { server.signature_help(p).await }
-                    .boxed()
-                    .compat(),
-            )
+        self.delegate_request::<SignatureHelpRequest, _, _>(params, move |p| async move {
+            server.signature_help(p).await
         })
     }
 
     fn goto_declaration(&self, params: Params) -> BoxFuture<Option<GotoDefinitionResponse>> {
         let server = self.server.clone();
-        self.delegate_request::<GotoDeclaration, _>(params, move |p| {
-            Box::new(
-                async move { server.goto_declaration(p).await }
-                    .boxed()
-                    .compat(),
-            )
+        self.delegate_request::<GotoDeclaration, _, _>(params, move |p| async move {
+            server.goto_declaration(p).await
         })
     }
 
     fn goto_definition(&self, params: Params) -> BoxFuture<Option<GotoDefinitionResponse>> {
         let server = self.server.clone();
-        self.delegate_request::<GotoDefinition, _>(params, move |p| {
-            Box::new(
-                async move { server.goto_definition(p).await }
-                    .boxed()
-                    .compat(),
-            )
+        self.delegate_request::<GotoDefinition, _, _>(params, move |p| async move {
+            server.goto_definition(p).await
         })
     }
 
@@ -338,59 +321,43 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
         params: Params,
     ) -> BoxFuture<Option<GotoTypeDefinitionResponse>> {
         let server = self.server.clone();
-        self.delegate_request::<GotoTypeDefinition, _>(params, move |p| {
-            Box::new(
-                async move { server.goto_type_definition(p).await }
-                    .boxed()
-                    .compat(),
-            )
+        self.delegate_request::<GotoTypeDefinition, _, _>(params, move |p| async move {
+            server.goto_type_definition(p).await
         })
     }
 
     fn goto_implementation(&self, params: Params) -> BoxFuture<Option<GotoImplementationResponse>> {
         let server = self.server.clone();
-        self.delegate_request::<GotoImplementation, _>(params, move |p| {
-            Box::new(
-                async move { server.goto_implementation(p).await }
-                    .boxed()
-                    .compat(),
-            )
+        self.delegate_request::<GotoImplementation, _, _>(params, move |p| async move {
+            server.goto_implementation(p).await
         })
     }
 
     fn document_highlight(&self, params: Params) -> BoxFuture<Option<Vec<DocumentHighlight>>> {
         let server = self.server.clone();
-        self.delegate_request::<DocumentHighlightRequest, _>(params, move |p| {
-            Box::new(
-                async move { server.document_highlight(p).await }
-                    .boxed()
-                    .compat(),
-            )
+        self.delegate_request::<DocumentHighlightRequest, _, _>(params, move |p| async move {
+            server.document_highlight(p).await
         })
     }
 
     fn code_action(&self, params: Params) -> BoxFuture<Option<CodeActionResponse>> {
         let server = self.server.clone();
-        self.delegate_request::<CodeActionRequest, _>(params, move |p| {
-            Box::new(async move { server.code_action(p).await }.boxed().compat())
+        self.delegate_request::<CodeActionRequest, _, _>(params, move |p| async move {
+            server.code_action(p).await
         })
     }
 
     fn code_lens(&self, params: Params) -> BoxFuture<Option<Vec<CodeLens>>> {
         let server = self.server.clone();
-        self.delegate_request::<CodeLensRequest, _>(params, move |p| {
-            Box::new(async move { server.code_lens(p).await }.boxed().compat())
+        self.delegate_request::<CodeLensRequest, _, _>(params, move |p| async move {
+            server.code_lens(p).await
         })
     }
 
     fn code_lens_resolve(&self, params: Params) -> BoxFuture<CodeLens> {
         let server = self.server.clone();
-        self.delegate_request::<CodeLensResolve, _>(params, move |p| {
-            Box::new(
-                async move { server.code_lens_resolve(p).await }
-                    .boxed()
-                    .compat(),
-            )
+        self.delegate_request::<CodeLensResolve, _, _>(params, move |p| async move {
+            server.code_lens_resolve(p).await
         })
     }
 }


### PR DESCRIPTION
### Changed

* Box `async` blocks and call `.boxed().compat()` inside one location rather than repeat it per-LSP request.

This should cut down on the amount of boilerplate and `std::future` compatibility noise seen in the `delegate.rs` module.