### PR TITLE
Check formatting only on beta Rust in CI for now

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
         rust-version: ${{ matrix.rust-version }}
     - uses: actions/checkout@v1
     - name: Check formatting
-      if: matrix.rust-version != 'nightly'
+      if: matrix.rust-version == 'beta'
       run: |
         rustup component add rustfmt
         cargo fmt --all -- --check


### PR DESCRIPTION
### Changed

* Check formatting only on `beta` Rust in CI for now.

It seems that #110 is refusing to merge due to the formatting rules for async/await being different on Rust 1.39 than on 1.41 (the current version at the time of writing). Although I have personally configured my editor to auto-format on save, we should have some static guarantees
about formatting present in CI.

Since we do not wish to disable these checks, but we want to also unblock #110, this commit checks formatting only against Rust beta for now, which is at least a newer version than 1.39.