### PR TITLE
Disable unused nom features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ jsonrpc-core = "14.0"
 jsonrpc-derive = "14.0"
 log = "0.4"
 lsp-types = "0.70"
-nom = "5.1"
+nom = { version = "5.1", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "0.2", features = ["rt-core"] }


### PR DESCRIPTION
### Changed

* Only depend on `nom` 5.1 with the `std` feature.

This should help us avoid pulling in unnecessary dependencies which could bloat compile times, such as `regex` and `lexical-core`. We don't compile regex nor parse floating-point numbers with `nom` in this crate, so the features for these can be turned off.