### PR TITLE
Handle backpressure and remove ExitReceiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,10 @@ async fn main() {
     let stdout = tokio::io::stdout();
 
     let (service, messages) = LspService::new(Backend::default());
-    let handle = service.close_handle();
-    let server = Server::new(stdin, stdout)
+    Server::new(stdin, stdout)
         .interleave(messages)
-        .serve(service);
-
-    handle.run_until_exit(server).await;
+        .serve(service)
+        .await;
 }
 ```
 

--- a/examples/custom_notification.rs
+++ b/examples/custom_notification.rs
@@ -103,10 +103,8 @@ async fn main() {
     let stdout = tokio::io::stdout();
 
     let (service, messages) = LspService::new(Backend::default());
-    let handle = service.close_handle();
-    let server = Server::new(stdin, stdout)
+    Server::new(stdin, stdout)
         .interleave(messages)
-        .serve(service);
-
-    handle.run_until_exit(server).await;
+        .serve(service)
+        .await;
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -107,10 +107,8 @@ async fn main() {
     let stdout = tokio::io::stdout();
 
     let (service, messages) = LspService::new(Backend::default());
-    let handle = service.close_handle();
-    let server = Server::new(stdin, stdout)
+    Server::new(stdin, stdout)
         .interleave(messages)
-        .serve(service);
-
-    handle.run_until_exit(server).await;
+        .serve(service)
+        .await;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,12 +53,10 @@
 //!     let stdout = tokio::io::stdout();
 //!
 //!     let (service, messages) = LspService::new(Backend::default());
-//!     let handle = service.close_handle();
-//!     let server = Server::new(stdin, stdout)
+//!     Server::new(stdin, stdout)
 //!         .interleave(messages)
-//!         .serve(service);
-//!
-//!     handle.run_until_exit(server).await;
+//!         .serve(service)
+//!         .await;
 //! }
 //! ```
 
@@ -70,7 +68,7 @@ pub extern crate lsp_types;
 
 pub use self::delegate::{MessageStream, Printer};
 pub use self::message::Incoming;
-pub use self::service::{ExitReceiver, ExitedError, LspService};
+pub use self::service::{ExitedError, LspService};
 pub use self::stdio::Server;
 /// A re-export of [`async-trait`](https://docs.rs/async-trait) for convenience.
 pub use async_trait::async_trait;

--- a/src/service.rs
+++ b/src/service.rs
@@ -138,7 +138,7 @@ impl Service<Incoming> for LspService {
 
     fn poll_ready(&mut self, _: &mut Context) -> Poll<Result<(), Self::Error>> {
         if self.stopped.load(Ordering::SeqCst) {
-            Poll::Pending
+            Poll::Ready(Err(ExitedError))
         } else {
             Poll::Ready(Ok(()))
         }
@@ -209,7 +209,7 @@ mod tests {
         assert_eq!(service.poll_ready(), Poll::Ready(Ok(())));
         assert_eq!(service.call(exit).await, Ok(None));
 
-        assert_eq!(service.poll_ready(), Poll::Pending);
+        assert_eq!(service.poll_ready(), Poll::Ready(Err(ExitedError)));
         assert_eq!(service.call(initialized).await, Err(ExitedError));
     }
 }


### PR DESCRIPTION
### Changed

* Return `Err` from `LspService::poll_ready()` if the `exit` notification is received.
* Gracefully shut down the `Server` once the underlying service's `poll_ready()` returns `Err`.

### Removed

* Remove `ExitReceiver` and `LspService::close_handle()`.
