### PR TITLE
Implement textDocument/documentSymbol request

### DIFF
--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -112,6 +112,9 @@ pub trait LanguageServerCore {
     #[rpc(name = "textDocument/implementation", raw_params)]
     fn goto_implementation(&self, params: Params) -> BoxFuture<Option<GotoImplementationResponse>>;
 
+    #[rpc(name = "textDocument/documentSymbol", raw_params)]
+    fn document_symbol(&self, params: Params) -> BoxFuture<Option<DocumentSymbolResponse>>;
+
     #[rpc(name = "textDocument/documentHighlight", raw_params)]
     fn document_highlight(&self, params: Params) -> BoxFuture<Option<Vec<DocumentHighlight>>>;
 
@@ -339,6 +342,13 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
         let server = self.server.clone();
         self.delegate_request::<GotoImplementation, _, _>(params, move |p| async move {
             server.goto_implementation(p).await
+        })
+    }
+
+    fn document_symbol(&self, params: Params) -> BoxFuture<Option<DocumentSymbolResponse>> {
+        let server = self.server.clone();
+        self.delegate_request::<DocumentSymbolRequest, _, _>(params, move |p| async move {
+            server.document_symbol(p).await
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,6 +397,29 @@ pub trait LanguageServer: Send + Sync + 'static {
         Err(Error::method_not_found())
     }
 
+    /// The [`textDocument/documentSymbol`] request is sent from the client to the server to
+    /// retrieve all symbols found in a given text document.
+    ///
+    /// The returned result is either:
+    ///
+    /// * [`DocumentSymbolResponse::Flat`] which is a flat list of all symbols found in a given
+    ///   text document. Then neither the symbol’s location range nor the symbol’s container name
+    ///   should be used to infer a hierarchy.
+    /// * [`DocumentSymbolResponse::Nested`] which is a hierarchy of symbols found in a given text
+    ///   document.
+    ///
+    /// [`textDocument/documentSymbol`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentSymbol
+    /// [`DocumentSymbolResponse::Flat`]: https://docs.rs/lsp-types/0.70.2/lsp_types/enum.DocumentSymbolResponse.html#variant.Flat
+    /// [`DocumentSymbolResponse::Nested`]: https://docs.rs/lsp-types/0.70.2/lsp_types/enum.DocumentSymbolResponse.html#variant.Nested
+    async fn document_symbol(
+        &self,
+        params: DocumentSymbolParams,
+    ) -> Result<Option<DocumentSymbolResponse>> {
+        let _ = params;
+        error!("Got a textDocument/documentSymbol request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
     /// The [`textDocument/documentHighlight`] request is sent from the client to the server to
     /// resolve appropriate highlights for a given text document position.
     ///
@@ -576,6 +599,13 @@ impl<S: ?Sized + LanguageServer> LanguageServer for Box<S> {
         params: TextDocumentPositionParams,
     ) -> Result<Option<GotoImplementationResponse>> {
         (**self).goto_implementation(params).await
+    }
+
+    async fn document_symbol(
+        &self,
+        params: DocumentSymbolParams,
+    ) -> Result<Option<DocumentSymbolResponse>> {
+        (**self).document_symbol(params).await
     }
 
     async fn document_highlight(


### PR DESCRIPTION
### Added

* Implement `textDocument/documentSymbol` request on server.

Affects #10.