### PR TITLE
Reduce chattiness of trace!() logs

### DIFF
--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -14,7 +14,7 @@ use futures::Stream;
 use jsonrpc_core::types::{ErrorCode, Params};
 use jsonrpc_core::{BoxFuture, Error, Result as RpcResult};
 use jsonrpc_derive::rpc;
-use log::error;
+use log::{error, info};
 use lsp_types::notification::{Notification, *};
 use lsp_types::request::{Request, *};
 use lsp_types::*;
@@ -203,6 +203,7 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
     fn initialize(&self, params: Params) -> RpcResult<InitializeResult> {
         let params: InitializeParams = params.parse()?;
         let response = self.server.initialize(&self.printer, params)?;
+        info!("language server initialized");
         self.initialized.store(true, Ordering::SeqCst);
         Ok(response)
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -11,7 +11,7 @@ use std::task::{Context, Poll};
 use futures::compat::Future01CompatExt;
 use futures::future::{self, TryFutureExt};
 use jsonrpc_core::IoHandler;
-use log::{debug, info, trace};
+use log::{debug, info};
 use lsp_types::notification::{Exit, Notification};
 use tower_service::Service;
 
@@ -111,12 +111,7 @@ impl Service<Incoming> for LspService {
                     self.handler
                         .handle_request(&request.to_string())
                         .compat()
-                        .map_err(|_| unreachable!())
-                        .inspect_ok(move |result| {
-                            if result.is_some() {
-                                trace!("request produced no response: {}", request);
-                            }
-                        }),
+                        .map_err(|_| unreachable!()),
                 )
             }
         }


### PR DESCRIPTION
### Added

* Add `info!()` message when server initializes, consistent with the existing `info!()` message emitted when the server exits.

### Removed

* Remove redundant `trace!()` log messages, since `jsonrpc-core` already provides its own equivalents.