### PR TITLE
Make notification trait methods async and non-blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ impl LanguageServer for Backend {
         Ok(InitializeResult::default())
     }
 
-    fn initialized(&self, printer: &Printer, _: InitializedParams) {
+    async fn initialized(&self, printer: &Printer, _: InitializedParams) {
         printer.log_message(MessageType::Info, "server initialized!");
     }
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -45,7 +45,7 @@ impl LanguageServer for Backend {
         })
     }
 
-    fn initialized(&self, printer: &Printer, _: InitializedParams) {
+    async fn initialized(&self, printer: &Printer, _: InitializedParams) {
         printer.log_message(MessageType::Info, "server initialized!");
     }
 
@@ -53,15 +53,19 @@ impl LanguageServer for Backend {
         Ok(())
     }
 
-    fn did_change_workspace_folders(&self, printer: &Printer, _: DidChangeWorkspaceFoldersParams) {
+    async fn did_change_workspace_folders(
+        &self,
+        printer: &Printer,
+        _: DidChangeWorkspaceFoldersParams,
+    ) {
         printer.log_message(MessageType::Info, "workspace folders changed!");
     }
 
-    fn did_change_configuration(&self, printer: &Printer, _: DidChangeConfigurationParams) {
+    async fn did_change_configuration(&self, printer: &Printer, _: DidChangeConfigurationParams) {
         printer.log_message(MessageType::Info, "configuration changed!");
     }
 
-    fn did_change_watched_files(&self, printer: &Printer, _: DidChangeWatchedFilesParams) {
+    async fn did_change_watched_files(&self, printer: &Printer, _: DidChangeWatchedFilesParams) {
         printer.log_message(MessageType::Info, "watched files have changed!");
     }
 
@@ -75,19 +79,19 @@ impl LanguageServer for Backend {
         Ok(None)
     }
 
-    fn did_open(&self, printer: &Printer, _: DidOpenTextDocumentParams) {
+    async fn did_open(&self, printer: &Printer, _: DidOpenTextDocumentParams) {
         printer.log_message(MessageType::Info, "file opened!");
     }
 
-    fn did_change(&self, printer: &Printer, _: DidChangeTextDocumentParams) {
+    async fn did_change(&self, printer: &Printer, _: DidChangeTextDocumentParams) {
         printer.log_message(MessageType::Info, "file changed!");
     }
 
-    fn did_save(&self, printer: &Printer, _: DidSaveTextDocumentParams) {
+    async fn did_save(&self, printer: &Printer, _: DidSaveTextDocumentParams) {
         printer.log_message(MessageType::Info, "file saved!");
     }
 
-    fn did_close(&self, printer: &Printer, _: DidCloseTextDocumentParams) {
+    async fn did_close(&self, printer: &Printer, _: DidCloseTextDocumentParams) {
         printer.log_message(MessageType::Info, "file closed!");
     }
 

--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -159,7 +159,7 @@ impl<T: LanguageServer> Delegate<T> {
 }
 
 macro_rules! delegate_notification {
-    ($name:ident as $notif:ty) => {
+    ($name:ident -> $notif:ty) => {
         fn $name(&self, params: Params) {
             if self.initialized.load(Ordering::SeqCst) {
                 match params.parse() {
@@ -176,7 +176,7 @@ macro_rules! delegate_notification {
 }
 
 macro_rules! delegate_request {
-    ($name:ident as $request:ty) => {
+    ($name:ident -> $request:ty) => {
         fn $name(&self, params: Params) -> BoxFuture<<$request as Request>::Result> {
             if self.initialized.load(Ordering::SeqCst) {
                 let server = self.server.clone();
@@ -207,7 +207,7 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
         Ok(response)
     }
 
-    delegate_notification!(initialized as Initialized);
+    delegate_notification!(initialized -> Initialized);
 
     fn shutdown(&self) -> BoxFuture<()> {
         if self.initialized.load(Ordering::SeqCst) {
@@ -218,10 +218,10 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
         }
     }
 
-    delegate_notification!(did_change_workspace_folders as DidChangeWorkspaceFolders);
-    delegate_notification!(did_change_configuration as DidChangeConfiguration);
-    delegate_notification!(did_change_watched_files as DidChangeWatchedFiles);
-    delegate_request!(symbol as WorkspaceSymbol);
+    delegate_notification!(did_change_workspace_folders -> DidChangeWorkspaceFolders);
+    delegate_notification!(did_change_configuration -> DidChangeConfiguration);
+    delegate_notification!(did_change_watched_files -> DidChangeWatchedFiles);
+    delegate_request!(symbol -> WorkspaceSymbol);
 
     fn execute_command(&self, params: Params) -> BoxFuture<Option<Value>> {
         if self.initialized.load(Ordering::SeqCst) {
@@ -243,26 +243,26 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
         }
     }
 
-    delegate_notification!(did_open as DidOpenTextDocument);
-    delegate_notification!(did_change as DidChangeTextDocument);
-    delegate_notification!(will_save as WillSaveTextDocument);
-    delegate_notification!(did_save as DidSaveTextDocument);
-    delegate_notification!(did_close as DidCloseTextDocument);
+    delegate_notification!(did_open -> DidOpenTextDocument);
+    delegate_notification!(did_change -> DidChangeTextDocument);
+    delegate_notification!(will_save -> WillSaveTextDocument);
+    delegate_notification!(did_save -> DidSaveTextDocument);
+    delegate_notification!(did_close -> DidCloseTextDocument);
 
-    delegate_request!(completion as Completion);
-    delegate_request!(completion_resolve as ResolveCompletionItem);
-    delegate_request!(hover as HoverRequest);
-    delegate_request!(signature_help as SignatureHelpRequest);
-    delegate_request!(goto_declaration as GotoDeclaration);
-    delegate_request!(goto_definition as GotoDefinition);
-    delegate_request!(goto_type_definition as GotoTypeDefinition);
-    delegate_request!(goto_implementation as GotoImplementation);
-    delegate_request!(document_symbol as DocumentSymbolRequest);
-    delegate_request!(document_highlight as DocumentHighlightRequest);
-    delegate_request!(code_action as CodeActionRequest);
-    delegate_request!(code_lens as CodeLensRequest);
-    delegate_request!(code_lens_resolve as CodeLensResolve);
-    delegate_request!(formatting as Formatting);
+    delegate_request!(completion -> Completion);
+    delegate_request!(completion_resolve -> ResolveCompletionItem);
+    delegate_request!(hover -> HoverRequest);
+    delegate_request!(signature_help -> SignatureHelpRequest);
+    delegate_request!(goto_declaration -> GotoDeclaration);
+    delegate_request!(goto_definition -> GotoDefinition);
+    delegate_request!(goto_type_definition -> GotoTypeDefinition);
+    delegate_request!(goto_implementation -> GotoImplementation);
+    delegate_request!(document_symbol -> DocumentSymbolRequest);
+    delegate_request!(document_highlight -> DocumentHighlightRequest);
+    delegate_request!(code_action -> CodeActionRequest);
+    delegate_request!(code_lens -> CodeLensRequest);
+    delegate_request!(code_lens_resolve -> CodeLensResolve);
+    delegate_request!(formatting -> Formatting);
 }
 
 /// Error response returned for every request received before the server is initialized.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //!         Ok(InitializeResult::default())
 //!     }
 //!
-//!     fn initialized(&self, printer: &Printer, _: InitializedParams) {
+//!     async fn initialized(&self, printer: &Printer, _: InitializedParams) {
 //!         printer.log_message(MessageType::Info, "server initialized!");
 //!     }
 //!
@@ -105,7 +105,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// capabilities with the client.
     ///
     /// [`initialized`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialized
-    fn initialized(&self, printer: &Printer, params: InitializedParams) {
+    async fn initialized(&self, printer: &Printer, params: InitializedParams) {
         let _ = printer;
         let _ = params;
     }
@@ -133,8 +133,12 @@ pub trait LanguageServer: Send + Sync + 'static {
     ///
     /// [`workspace/didChangeWorkspaceFolders`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_didChangeWorkspaceFolders
     /// [`initialize`]: #tymethod.initialize
-    fn did_change_workspace_folders(&self, p: &Printer, params: DidChangeWorkspaceFoldersParams) {
-        let _ = p;
+    async fn did_change_workspace_folders(
+        &self,
+        printer: &Printer,
+        params: DidChangeWorkspaceFoldersParams,
+    ) {
+        let _ = printer;
         let _ = params;
         warn!("Got a workspace/didChangeWorkspaceFolders notification, but it is not implemented");
     }
@@ -143,7 +147,11 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// to signal the change of configuration settings.
     ///
     /// [`workspace/didChangeConfiguration`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_didChangeConfiguration
-    fn did_change_configuration(&self, printer: &Printer, params: DidChangeConfigurationParams) {
+    async fn did_change_configuration(
+        &self,
+        printer: &Printer,
+        params: DidChangeConfigurationParams,
+    ) {
         let _ = printer;
         let _ = params;
         warn!("Got a workspace/didChangeConfiguration notification, but it is not implemented");
@@ -158,7 +166,11 @@ pub trait LanguageServer: Send + Sync + 'static {
     ///
     /// [`workspace/didChangeWatchedFiles`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_didChangeConfiguration
     /// [`initialized`]: #tymethod.initialized
-    fn did_change_watched_files(&self, printer: &Printer, params: DidChangeWatchedFilesParams) {
+    async fn did_change_watched_files(
+        &self,
+        printer: &Printer,
+        params: DidChangeWatchedFilesParams,
+    ) {
         let _ = printer;
         let _ = params;
         warn!("Got a workspace/didChangeWatchedFiles notification, but it is not implemented");
@@ -203,7 +215,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// client. It doesn't necessarily mean that its content is presented in an editor.
     ///
     /// [`textDocument/didOpen`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didOpen
-    fn did_open(&self, printer: &Printer, params: DidOpenTextDocumentParams) {
+    async fn did_open(&self, printer: &Printer, params: DidOpenTextDocumentParams) {
         let _ = printer;
         let _ = params;
         warn!("Got a textDocument/didOpen notification, but it is not implemented");
@@ -216,7 +228,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// document for the server to interpret.
     ///
     /// [`textDocument/didChange`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didChange
-    fn did_change(&self, printer: &Printer, params: DidChangeTextDocumentParams) {
+    async fn did_change(&self, printer: &Printer, params: DidChangeTextDocumentParams) {
         let _ = printer;
         let _ = params;
         warn!("Got a textDocument/didChange notification, but it is not implemented");
@@ -226,7 +238,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// document is actually saved.
     ///
     /// [`textDocument/willSave`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_willSave
-    fn will_save(&self, printer: &Printer, params: WillSaveTextDocumentParams) {
+    async fn will_save(&self, printer: &Printer, params: WillSaveTextDocumentParams) {
         let _ = printer;
         let _ = params;
         warn!("Got a textDocument/willSave notification, but it is not implemented");
@@ -236,7 +248,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// document was saved in the client.
     ///
     /// [`textDocument/didSave`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didSave
-    fn did_save(&self, printer: &Printer, params: DidSaveTextDocumentParams) {
+    async fn did_save(&self, printer: &Printer, params: DidSaveTextDocumentParams) {
         let _ = printer;
         let _ = params;
         warn!("Got a textDocument/didSave notification, but it is not implemented");
@@ -249,7 +261,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// URI is a file URI, the truth now exists on disk).
     ///
     /// [`textDocument/didClose`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didClose
-    fn did_close(&self, printer: &Printer, params: DidCloseTextDocumentParams) {
+    async fn did_close(&self, printer: &Printer, params: DidCloseTextDocumentParams) {
         let _ = printer;
         let _ = params;
         warn!("Got a textDocument/didClose notification, but it is not implemented");
@@ -509,24 +521,36 @@ impl<S: ?Sized + LanguageServer> LanguageServer for Box<S> {
         (**self).initialize(printer, params)
     }
 
-    fn initialized(&self, printer: &Printer, params: InitializedParams) {
-        (**self).initialized(printer, params);
+    async fn initialized(&self, printer: &Printer, params: InitializedParams) {
+        (**self).initialized(printer, params).await;
     }
 
     async fn shutdown(&self) -> Result<()> {
         (**self).shutdown().await
     }
 
-    fn did_change_workspace_folders(&self, p: &Printer, params: DidChangeWorkspaceFoldersParams) {
-        (**self).did_change_workspace_folders(p, params);
+    async fn did_change_workspace_folders(
+        &self,
+        printer: &Printer,
+        params: DidChangeWorkspaceFoldersParams,
+    ) {
+        (**self).did_change_workspace_folders(printer, params).await;
     }
 
-    fn did_change_configuration(&self, printer: &Printer, params: DidChangeConfigurationParams) {
-        (**self).did_change_configuration(printer, params);
+    async fn did_change_configuration(
+        &self,
+        printer: &Printer,
+        params: DidChangeConfigurationParams,
+    ) {
+        (**self).did_change_configuration(printer, params).await;
     }
 
-    fn did_change_watched_files(&self, printer: &Printer, params: DidChangeWatchedFilesParams) {
-        (**self).did_change_watched_files(printer, params);
+    async fn did_change_watched_files(
+        &self,
+        printer: &Printer,
+        params: DidChangeWatchedFilesParams,
+    ) {
+        (**self).did_change_watched_files(printer, params).await;
     }
 
     async fn symbol(
@@ -544,24 +568,24 @@ impl<S: ?Sized + LanguageServer> LanguageServer for Box<S> {
         (**self).execute_command(p, params).await
     }
 
-    fn did_open(&self, printer: &Printer, params: DidOpenTextDocumentParams) {
-        (**self).did_open(printer, params);
+    async fn did_open(&self, printer: &Printer, params: DidOpenTextDocumentParams) {
+        (**self).did_open(printer, params).await;
     }
 
-    fn did_change(&self, printer: &Printer, params: DidChangeTextDocumentParams) {
-        (**self).did_change(printer, params);
+    async fn did_change(&self, printer: &Printer, params: DidChangeTextDocumentParams) {
+        (**self).did_change(printer, params).await;
     }
 
-    fn will_save(&self, printer: &Printer, params: WillSaveTextDocumentParams) {
-        (**self).will_save(printer, params);
+    async fn will_save(&self, printer: &Printer, params: WillSaveTextDocumentParams) {
+        (**self).will_save(printer, params).await;
     }
 
-    fn did_save(&self, printer: &Printer, params: DidSaveTextDocumentParams) {
-        (**self).did_save(printer, params);
+    async fn did_save(&self, printer: &Printer, params: DidSaveTextDocumentParams) {
+        (**self).did_save(printer, params).await;
     }
 
-    fn did_close(&self, printer: &Printer, params: DidCloseTextDocumentParams) {
-        (**self).did_close(printer, params);
+    async fn did_close(&self, printer: &Printer, params: DidCloseTextDocumentParams) {
+        (**self).did_close(printer, params).await;
     }
 
     async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {


### PR DESCRIPTION
### Changed

* Make all `LanguageServer` notification trait methods `async fn` and non-blocking.

This pull request makes all `LanguageServer` notification methods `async fn` so that we can `.await` on client responses inside these method bodies, once we implement proper server-to-client communication later on. Instead of spawning these requests with `tokio::spawn()`, as we currently do in `Printer`, we could `.await` them directly inside these methods without blocking the executor.

This also replaces the internal `Delegate::delegate_request()` and `Delegate::delegate_notification()` methods with `delegate_request!()` and the `delegate_notification!()` macros, respectively, to avoid the nested `.await`s and avoiding lifetime woes caused by the lack of proper async closures in the language. Perhaps once async closures get added to Rust later on, we could re-evaluate whether to replace them with dedicated methods again.

Affects #13.

CC @icsaszar 