### PR TITLE
Implement proper client request support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust-version: [1.39.0, beta, nightly]
+        rust-version: [1.40.0, beta, nightly]
         include:
         - rust-version: nightly
           continue-on-error: true
@@ -20,7 +20,7 @@ jobs:
         rust-version: ${{ matrix.rust-version }}
     - uses: actions/checkout@v1
     - name: Check formatting
-      if: matrix.rust-version == 'beta'
+      if: matrix.rust-version != 'nightly'
       run: |
         rustup component add rustfmt
         cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["language-server", "lsp", "tower"]
 [dependencies]
 async-trait = "0.1"
 bytes = "0.5"
+dashmap = "3.5.1"
 futures = { version = "0.3", features = ["compat"] }
 jsonrpc-core = "14.0"
 jsonrpc-derive = "14.0"

--- a/examples/custom_notification.rs
+++ b/examples/custom_notification.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use serde_json::Value;
 use tower_lsp::lsp_types::notification::Notification;
 use tower_lsp::lsp_types::*;
-use tower_lsp::{LanguageServer, LspService, Printer, Server};
+use tower_lsp::{Client, LanguageServer, LspService, Server};
 
 #[derive(Debug, Serialize)]
 struct CustomNotificationParams {
@@ -33,7 +33,7 @@ struct Backend;
 
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
-    fn initialize(&self, _: &Printer, _: InitializeParams) -> Result<InitializeResult> {
+    fn initialize(&self, _: &Client, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {
             server_info: None,
             capabilities: ServerCapabilities {
@@ -79,15 +79,15 @@ impl LanguageServer for Backend {
 
     async fn execute_command(
         &self,
-        printer: &Printer,
+        client: &Client,
         params: ExecuteCommandParams,
     ) -> Result<Option<Value>> {
         if &params.command == "custom.notification" {
-            printer.send_notification::<CustomNotification>(CustomNotificationParams::new(
+            client.send_custom_notification::<CustomNotification>(CustomNotificationParams::new(
                 "Hello", "Message",
             ));
         }
-        printer.log_message(
+        client.log_message(
             MessageType::Info,
             format!("command executed!: {:?}", params),
         );

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -75,9 +75,10 @@ impl LanguageServer for Backend {
         _: ExecuteCommandParams,
     ) -> Result<Option<Value>> {
         client.log_message(MessageType::Info, "command executed!");
+
         match client.apply_edit(WorkspaceEdit::default()).await {
             Ok(res) if res.applied => client.log_message(MessageType::Info, "edit applied"),
-            Ok(_) => client.log_message(MessageType::Info, "edit applied"),
+            Ok(_) => client.log_message(MessageType::Info, "edit not applied"),
             Err(err) => client.log_message(MessageType::Error, err),
         }
 

--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -36,6 +36,7 @@ impl Stream for MessageStream {
     }
 }
 
+/// Routes responses from the language client back to the server.
 #[derive(Clone, Debug)]
 pub struct MessageSender(Sender<Output>);
 

--- a/src/delegate/client.rs
+++ b/src/delegate/client.rs
@@ -164,7 +164,7 @@ impl Client {
         .await
     }
 
-    /// Fetch the current open list of workspace folders.
+    /// Fetches the current open list of workspace folders.
     ///
     /// Returns `None` if only a single file is open in the tool. Returns an empty `Vec` if a
     /// workspace is open but no folders are configured.

--- a/src/delegate/client.rs
+++ b/src/delegate/client.rs
@@ -169,7 +169,7 @@ impl Client {
             let response = self
                 .pending_requests
                 .remove_if(&id, |_, v| v.is_some())
-                .and_then(|entry| entry.1);
+                .and_then(|(_, v)| v);
 
             match response {
                 Some(Output::Success(s)) => {

--- a/src/delegate/client.rs
+++ b/src/delegate/client.rs
@@ -164,6 +164,38 @@ impl Client {
         .await
     }
 
+    /// Fetch the current open list of workspace folders.
+    ///
+    /// Returns `None` if only a single file is open in the tool. Returns an empty `Vec` if a
+    /// workspace is open but no folders are configured.
+    ///
+    /// This corresponds to the [`workspace/workspaceFolders`] request.
+    ///
+    /// [`workspace/workspaceFolders`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_workspaceFolders
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.6.0 and requires client-side support
+    /// in order to be used. It can only be called if the client set the following field to `true`
+    /// in the [`LanguageServer::initialize`] method:
+    ///
+    /// ```text
+    /// InitializeParams::capabilities::workspace::workspace_folders
+    /// ```
+    ///
+    /// [`LanguageServer::initialize`]: #tymethod.initialize
+    ///
+    /// # Initialization
+    ///
+    /// If the request is sent to client before the server has been initialized, this will
+    /// immediately return `Err` with JSON-RPC error code `-32002` ([read more]).
+    ///
+    /// [read more]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize
+    pub async fn workspace_folders(&self) -> Result<Option<Vec<WorkspaceFolder>>> {
+        self.send_request_initialized::<WorkspaceFoldersRequest>(())
+            .await
+    }
+
     /// Fetches configuration settings from the client.
     ///
     /// The request can fetch several configuration settings in one roundtrip. The order of the

--- a/src/delegate/client.rs
+++ b/src/delegate/client.rs
@@ -164,6 +164,42 @@ impl Client {
         .await
     }
 
+    /// Fetches configuration settings from the client.
+    ///
+    /// The request can fetch several configuration settings in one roundtrip. The order of the
+    /// returned configuration settings correspond to the order of the passed
+    /// [`ConfigurationItem`]s (e.g. the first item in the response is the result for the first
+    /// configuration item in the params).
+    ///
+    /// [`ConfigurationItem`]: https://docs.rs/lsp-types/0.70.2/lsp_types/struct.ConfigurationItem.html
+    ///
+    /// This corresponds to the [`workspace/configuration`] request.
+    ///
+    /// [`workspace/configuration`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_configuration
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.6.0 and requires client-side support
+    /// in order to be used. It can only be called if the client set the following field to `true`
+    /// in the [`LanguageServer::initialize`] method:
+    ///
+    /// ```text
+    /// InitializeParams::capabilities::workspace::configuration
+    /// ```
+    ///
+    /// [`LanguageServer::initialize`]: #tymethod.initialize
+    ///
+    /// # Initialization
+    ///
+    /// If the request is sent to client before the server has been initialized, this will
+    /// immediately return `Err` with JSON-RPC error code `-32002` ([read more]).
+    ///
+    /// [read more]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize
+    pub async fn configuration(&self, items: Vec<ConfigurationItem>) -> Result<Vec<Value>> {
+        self.send_request_initialized::<WorkspaceConfiguration>(ConfigurationParams { items })
+            .await
+    }
+
     /// Requests a workspace resource be edited on the client side and returns whether the edit was
     /// applied.
     ///

--- a/src/delegate/client.rs
+++ b/src/delegate/client.rs
@@ -36,13 +36,13 @@ impl Client {
 
         let pending = pending_requests.clone();
         tokio::spawn(async move {
-            loop {
-                while let Some(response) = receiver.next().await {
-                    if let Id::Num(ref id) = response.id() {
+            while let Some(response) = receiver.next().await {
+                match response.id() {
+                    Id::Num(ref id) if pending.contains_key(id) => {
                         pending.insert(*id, Some(response));
-                    } else {
-                        error!("received response from client with non-numeric ID");
                     }
+                    Id::Num(_) => error!("received response from client with no matching request"),
+                    _ => error!("received response from client with non-numeric ID"),
                 }
             }
         });

--- a/src/delegate/client.rs
+++ b/src/delegate/client.rs
@@ -157,13 +157,14 @@ impl Client {
         R::Result: DeserializeOwned,
     {
         let id = self.request_id.fetch_add(1, Ordering::SeqCst);
-        self.pending_requests.insert(id, None);
-
         let message = make_request::<R>(id, params);
+
         if self.sender.clone().send(message).await.is_err() {
             error!("failed to send request");
             return Err(Error::internal_error());
         }
+
+        self.pending_requests.insert(id, None);
 
         loop {
             let response = self

--- a/src/delegate/client.rs
+++ b/src/delegate/client.rs
@@ -41,7 +41,7 @@ impl Client {
                     if let Id::Num(ref id) = response.id() {
                         pending.insert(*id, Some(response));
                     } else {
-                        error!("expected numeric ID from client",);
+                        error!("received response from client with non-numeric ID");
                     }
                 }
             }
@@ -285,14 +285,14 @@ mod tests {
     use super::*;
 
     async fn assert_client_messages<F: FnOnce(Client)>(f: F, expected: String) {
-        let (req_tx, req_rx) = mpsc::channel(1);
-        let (res_tx, res_rx) = mpsc::channel(1);
+        let (request_tx, request_rx) = mpsc::channel(1);
+        let (response_tx, response_rx) = mpsc::channel(1);
 
-        let client = Client::new(req_tx, res_rx, Arc::new(AtomicBool::new(true)));
+        let client = Client::new(request_tx, response_rx, Arc::new(AtomicBool::new(true)));
         f(client);
-        drop(res_tx);
+        drop(response_tx);
 
-        let messages: Vec<_> = req_rx.collect().await;
+        let messages: Vec<_> = request_rx.collect().await;
         assert_eq!(messages, vec![expected]);
     }
 

--- a/src/delegate/client.rs
+++ b/src/delegate/client.rs
@@ -12,7 +12,7 @@ use jsonrpc_core::types::{ErrorCode, Id, Output, Version};
 use jsonrpc_core::{Error, Result};
 use log::{error, trace};
 use lsp_types::notification::{Notification, *};
-use lsp_types::request::{ApplyWorkspaceEdit, RegisterCapability, Request, UnregisterCapability};
+use lsp_types::request::{Request, *};
 use lsp_types::*;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
@@ -79,6 +79,35 @@ impl Client {
             typ,
             message: message.to_string(),
         });
+    }
+
+    /// Asks the client to display a particular message in the user interface.
+    ///
+    /// In addition to the `show_message` notification, the request allows to pass actions and to
+    /// wait for an answer from the client.
+    ///
+    /// This corresponds to the [`window/showMessageRequest`] request.
+    ///
+    /// [`window/showMessageRequest`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#window_showMessageRequest
+    ///
+    /// # Initialization
+    ///
+    /// If the request is sent to client before the server has been initialized, this will
+    /// immediately return `Err` with JSON-RPC error code `-32002` ([read more]).
+    ///
+    /// [read more]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize
+    pub async fn show_message_request<M: Display>(
+        &self,
+        typ: MessageType,
+        message: M,
+        actions: Option<Vec<MessageActionItem>>,
+    ) -> Result<Option<MessageActionItem>> {
+        self.send_request_initialized::<ShowMessageRequest>(ShowMessageRequestParams {
+            typ,
+            message: message.to_string(),
+            actions,
+        })
+        .await
     }
 
     /// Notifies the client to log a telemetry event.

--- a/src/delegate/client.rs
+++ b/src/delegate/client.rs
@@ -128,7 +128,7 @@ impl Client {
         }
     }
 
-    /// Register a new capability with the client.
+    /// Registers a new capability with the client.
     ///
     /// This corresponds to the [`client/registerCapability`] request.
     ///
@@ -145,7 +145,7 @@ impl Client {
             .await
     }
 
-    /// Unregister a capability with the client.
+    /// Unregisters a capability with the client.
     ///
     /// This corresponds to the [`client/unregisterCapability`] request.
     ///

--- a/src/delegate/client.rs
+++ b/src/delegate/client.rs
@@ -159,8 +159,8 @@ impl Client {
         let id = self.request_id.fetch_add(1, Ordering::SeqCst);
         self.pending_requests.insert(id, None);
 
-        let request = make_request::<R>(id, params);
-        if self.sender.clone().send(request).await.is_err() {
+        let message = make_request::<R>(id, params);
+        if self.sender.clone().send(message).await.is_err() {
             error!("failed to send request");
             return Err(Error::internal_error());
         }

--- a/src/delegate/printer.rs
+++ b/src/delegate/printer.rs
@@ -20,17 +20,17 @@ use serde_json::Value;
 /// Sends notifications from the language server to the client.
 #[derive(Debug)]
 pub struct Printer {
-    buffer: Sender<String>,
-    initialized: Arc<AtomicBool>,
-    request_id: AtomicU64,
+    router: Router,
 }
 
 impl Printer {
-    pub(super) const fn new(buffer: Sender<String>, initialized: Arc<AtomicBool>) -> Self {
+    pub(super) const fn new(
+        tx: Sender<String>,
+        rx: Receiver<Output>,
+        initialized: Arc<AtomicBool>,
+    ) -> Self {
         Printer {
-            buffer,
-            initialized,
-            request_id: AtomicU64::new(0),
+            router: Router::new(tx, rx, initialized),
         }
     }
 
@@ -40,10 +40,11 @@ impl Printer {
     ///
     /// [`window/logMessage`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#window_logMessage
     pub fn log_message<M: Display>(&self, typ: MessageType, message: M) {
-        self.send_message(make_notification::<LogMessage>(LogMessageParams {
-            typ,
-            message: message.to_string(),
-        }));
+        self.router
+            .send_notification::<LogMessage>(LogMessageParams {
+                typ,
+                message: message.to_string(),
+            });
     }
 
     /// Notifies the client to display a particular message in the user interface.
@@ -52,10 +53,11 @@ impl Printer {
     ///
     /// [`window/showMessage`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#window_showMessage
     pub fn show_message<M: Display>(&self, typ: MessageType, message: M) {
-        self.send_message(make_notification::<ShowMessage>(ShowMessageParams {
-            typ,
-            message: message.to_string(),
-        }));
+        self.router
+            .send_notification::<ShowMessage>(ShowMessageParams {
+                typ,
+                message: message.to_string(),
+            });
     }
 
     /// Notifies the client to log a telemetry event.
@@ -69,9 +71,9 @@ impl Printer {
             Ok(value) => {
                 if !value.is_null() && !value.is_array() && !value.is_object() {
                     let value = Value::Array(vec![value]);
-                    self.send_message(make_notification::<TelemetryEvent>(value));
+                    self.router.send_notification::<TelemetryEvent>(value);
                 } else {
-                    self.send_message(make_notification::<TelemetryEvent>(value));
+                    self.router.send_notification::<TelemetryEvent>(value);
                 }
             }
         }
@@ -82,13 +84,10 @@ impl Printer {
     /// This corresponds to the [`client/registerCapability`] request.
     ///
     /// [`client/registerCapability`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#client_registerCapability
-    pub fn register_capability(&self, registrations: Vec<Registration>) {
-        // FIXME: Check whether the request succeeded or failed.
-        let id = self.request_id.fetch_add(1, Ordering::SeqCst);
-        self.send_message_initialized(make_request::<RegisterCapability>(
-            id,
-            RegistrationParams { registrations },
-        ))
+    pub async fn register_capability(&self, registrations: Vec<Registration>) -> Result<()> {
+        self.router
+            .send_request_initialized::<RegisterCapability>(RegistrationParams { registrations })
+            .await
     }
 
     /// Unregister a capability with the client.
@@ -96,13 +95,12 @@ impl Printer {
     /// This corresponds to the [`client/unregisterCapability`] request.
     ///
     /// [`client/unregisterCapability`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#client_unregisterCapability
-    pub fn unregister_capability(&self, unregisterations: Vec<Unregistration>) {
-        // FIXME: Check whether the request succeeded or failed.
-        let id = self.request_id.fetch_add(1, Ordering::SeqCst);
-        self.send_message_initialized(make_request::<UnregisterCapability>(
-            id,
-            UnregistrationParams { unregisterations },
-        ))
+    pub async fn unregister_capability(&self, unregisterations: Vec<Unregistration>) -> Result<()> {
+        self.router
+            .send_request_initialized::<UnregisterCapability>(UnregistrationParams {
+                unregisterations,
+            })
+            .await
     }
 
     /// Requests a workspace resource be edited on the client side and returns whether the edit was
@@ -111,14 +109,10 @@ impl Printer {
     /// This corresponds to the [`workspace/applyEdit`] request.
     ///
     /// [`workspace/applyEdit`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_applyEdit
-    pub fn apply_edit(&self, edit: WorkspaceEdit) -> bool {
-        // FIXME: Check whether the request succeeded or failed and retrieve apply status.
-        let id = self.request_id.fetch_add(1, Ordering::SeqCst);
-        self.send_message_initialized(make_request::<ApplyWorkspaceEdit>(
-            id,
-            ApplyWorkspaceEditParams { edit },
-        ));
-        true
+    pub async fn apply_edit(&self, edit: WorkspaceEdit) -> Result<ApplyWorkspaceEditResponse> {
+        self.router
+            .send_request_initialized::<ApplyWorkspaceEdit>(ApplyWorkspaceEditParams { edit })
+            .await
     }
 
     /// Submits validation diagnostics for an open file with the given URI.
@@ -127,9 +121,10 @@ impl Printer {
     ///
     /// [`textDocument/publishDiagnostics`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_publishDiagnostics
     pub fn publish_diagnostics(&self, uri: Url, diags: Vec<Diagnostic>, version: Option<i64>) {
-        self.send_message_initialized(make_notification::<PublishDiagnostics>(
-            PublishDiagnosticsParams::new(uri, diags, version),
-        ));
+        self.router
+            .send_notification_initialized::<PublishDiagnostics>(PublishDiagnosticsParams::new(
+                uri, diags, version,
+            ));
     }
 
     /// Sends a custom notification to the client.
@@ -138,42 +133,26 @@ impl Printer {
         N: Notification,
         N::Params: Serialize,
     {
-        self.send_message_initialized(make_notification::<N>(params));
-    }
-
-    fn send_message(&self, message: String) {
-        let mut buffer = self.buffer.clone();
-        tokio::spawn(async move {
-            if buffer.send(message).await.is_err() {
-                error!("failed to send message")
-            }
-        });
-    }
-
-    fn send_message_initialized(&self, message: String) {
-        if self.initialized.load(Ordering::SeqCst) {
-            self.send_message(message)
-        } else {
-            trace!("server not initialized, supressing message: {}", message);
-        }
+        self.router.send_notification_initialized::<N>(params);
     }
 }
 
 #[derive(Debug)]
 struct Router {
     sender: Sender<String>,
+    initialized: Arc<AtomicBool>,
     request_id: AtomicU64,
     pending_requests: Arc<DashMap<u64, Option<Output>>>,
 }
 
 impl Router {
-    fn new(sender: Sender<String>, mut receiver: Receiver<Output>) -> Self {
+    fn new(tx: Sender<String>, mut rx: Receiver<Output>, initialized: Arc<AtomicBool>) -> Self {
         let pending_requests = Arc::new(DashMap::default());
 
         let pending = pending_requests.clone();
         tokio::spawn(async move {
             loop {
-                while let Some(response) = receiver.next().await {
+                while let Some(response) = rx.next().await {
                     if let Id::Num(ref id) = response.id() {
                         pending.insert(*id, Some(response));
                     } else {
@@ -184,7 +163,8 @@ impl Router {
         });
 
         Router {
-            sender,
+            sender: tx,
+            initialized,
             request_id: AtomicU64::new(0),
             pending_requests,
         }
@@ -233,6 +213,35 @@ impl Router {
                 error!("failed to send notification")
             }
         });
+    }
+
+    async fn send_request_initialized<R>(&self, params: R::Params) -> Result<R::Result>
+    where
+        R: Request,
+        R::Params: Serialize,
+        R::Result: DeserializeOwned,
+    {
+        if self.initialized.load(Ordering::SeqCst) {
+            self.send_request::<R>(params).await
+        } else {
+            let id = self.request_id.load(Ordering::SeqCst) + 1;
+            let msg = make_request::<R>(id, params);
+            trace!("server not initialized, supressing message: {}", msg);
+            Err(Error::internal_error())
+        }
+    }
+
+    fn send_notification_initialized<N>(&self, params: N::Params)
+    where
+        N: Notification,
+        N::Params: Serialize,
+    {
+        if self.initialized.load(Ordering::SeqCst) {
+            self.send_notification::<N>(params);
+        } else {
+            let msg = make_notification::<N>(params);
+            trace!("server not initialized, supressing message: {}", msg);
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,24 +468,25 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// `ServerCapabilities::execute_command_provider`). If the client supports providing edits
     /// with a code action then the mode should be used.
     ///
-    /// When the command is selected the server should be contacted again
-    /// (via the [`workspace/executeCommand`]) request to execute the command.
+    /// When the command is selected the server should be contacted again (via the
+    /// [`workspace/executeCommand`] request) to execute the command.
+    ///
+    /// # Compatibility
     ///
     /// Since version 3.8.0: support for `CodeAction` literals to enable the following scenarios:
     ///
-    /// - the ability to directly return a workspace edit from the code action request.
-    /// This avoids having another server roundtrip to execute an actual code action.
-    /// However server providers should be aware that if the code action is expensive to compute or
-    /// the edits are huge it might still be beneficial if the result is simply a command and the
-    /// actual edit is only computed when needed.
+    /// * The ability to directly return a workspace edit from the code action request.
+    ///   This avoids having another server roundtrip to execute an actual code action.
+    ///   However server providers should be aware that if the code action is expensive to compute
+    ///   or the edits are huge it might still be beneficial if the result is simply a command and
+    ///   the actual edit is only computed when needed.
     ///
-    /// - the ability to group code actions using a kind. Clients are allowed to ignore that
-    /// information. However it allows them to better group code action for example into
-    /// corresponding menus (e.g. all refactor code actions into a refactor menu).
+    /// * The ability to group code actions using a kind. Clients are allowed to ignore that
+    ///   information. However it allows them to better group code action for example into
+    ///   corresponding menus (e.g. all refactor code actions into a refactor menu).
     ///
     /// [`textDocument/codeAction`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
     /// [`workspace/executeCommand`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_executeCommand
-    ///
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
         let _ = params;
         error!("Got a textDocument/codeAction request, but it is not implemented");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,16 +316,19 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// The [`textDocument/declaration`] request asks the server for the declaration location of a
     /// symbol at a given text document position.
     ///
+    /// [`textDocument/declaration`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_declaration
+    ///
+    /// # Compatibility
+    ///
     /// The [`GotoDefinitionResponse::Link`] return value was introduced in specification version
-    /// 3.14.0 and requires client-side support. It can be returned if the client set the following
-    /// field to `true` in the [`initialize`] method:
+    /// 3.14.0 and requires client-side support in order to be used. It can be returned if the
+    /// client set the following field to `true` in the [`initialize`] method:
     ///
     /// ```text
     /// InitializeParams::capabilities::text_document::declaration::link_support
     /// ```
     ///
-    /// [`textDocument/declaration`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_declaration
-    /// [`GotoDefinitionResponse::Link`]: https://docs.rs/lsp-types/0.63.1/lsp_types/request/enum.GotoDefinitionResponse.html#variant.Link
+    /// [`GotoDefinitionResponse::Link`]: https://docs.rs/lsp-types/0.70.2/lsp_types/request/enum.GotoDefinitionResponse.html#variant.Link
     /// [`initialize`]: #tymethod.initialize
     async fn goto_declaration(
         &self,
@@ -339,16 +342,19 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// The [`textDocument/definition`] request asks the server for the definition location of a
     /// symbol at a given text document position.
     ///
+    /// [`textDocument/definition`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_definition
+    ///
+    /// # Compatibility
+    ///
     /// The [`GotoDefinitionResponse::Link`] return value was introduced in specification version
-    /// 3.14.0 and requires client-side support. It can be returned if the client set the following
-    /// field to `true` in the [`initialize`] method:
+    /// 3.14.0 and requires client-side support in order to be used. It can be returned if the
+    /// client set the following field to `true` in the [`initialize`] method:
     ///
     /// ```text
     /// InitializeParams::capabilities::text_document::definition::link_support
     /// ```
     ///
-    /// [`textDocument/definition`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_definition
-    /// [`GotoDefinitionResponse::Link`]: https://docs.rs/lsp-types/0.63.1/lsp_types/request/enum.GotoDefinitionResponse.html#variant.Link
+    /// [`GotoDefinitionResponse::Link`]: https://docs.rs/lsp-types/0.70.2/lsp_types/request/enum.GotoDefinitionResponse.html#variant.Link
     /// [`initialize`]: #tymethod.initialize
     async fn goto_definition(
         &self,
@@ -362,16 +368,18 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// The [`textDocument/typeDefinition`] request asks the server for the type definition location of
     /// a symbol at a given text document position.
     ///
+    /// [`textDocument/typeDefinition`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_typeDefinition
+    ///
+    /// # Compatibility
+    ///
     /// The [`GotoDefinitionResponse::Link`] return value was introduced in specification version
-    /// 3.14.0 and requires client-side support. It can be returned if the client set the following
-    /// field to `true` in the [`initialize`] method:
+    /// 3.14.0 and requires client-side support in order to be used. It can be returned if the
+    /// client set the following field to `true` in the [`initialize`] method:
     ///
     /// ```text
     /// InitializeParams::capabilities::text_document::type_definition::link_support
     /// ```
-    ///
-    /// [`textDocument/typeDefinition`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_typeDefinition
-    /// [`GotoDefinitionResponse::Link`]: https://docs.rs/lsp-types/0.63.1/lsp_types/request/enum.GotoDefinitionResponse.html#variant.Link
+    /// [`GotoDefinitionResponse::Link`]: https://docs.rs/lsp-types/0.70.2/lsp_types/request/enum.GotoDefinitionResponse.html#variant.Link
     /// [`initialize`]: #tymethod.initialize
     async fn goto_type_definition(
         &self,
@@ -385,16 +393,18 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// The [`textDocument/implementation`] request is sent from the client to the server to resolve
     /// the implementation location of a symbol at a given text document position.
     ///
-    /// The result type [`GotoImplementationResponse::Link`] got introduced with version 3.14.0 and
-    /// requires client-side support. It can be returned if the client set the following
-    /// field to `true` in the [`initialize`] method:
+    /// [`textDocument/implementation`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_implementation
+    ///
+    /// # Compatibility
+    ///
+    /// The [`GotoImplementationResponse::Link`] return value was introduced in specification
+    /// version 3.14.0 and requires client-side support in order to be used. It can be returned if
+    /// the client set the following field to `true` in the [`initialize`] method:
     ///
     /// ```text
     /// InitializeParams::capabilities::text_document::implementation::link_support
     /// ```
-    ///
-    /// [`textDocument/implementation`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_implementation
-    /// [`GotoImplementationResponse::Link`]: https://docs.rs/lsp-types/0.63.1/lsp_types/request/enum.GotoDefinitionResponse.html
+    /// [`GotoImplementationResponse::Link`]: https://docs.rs/lsp-types/0.70.2/lsp_types/request/enum.GotoDefinitionResponse.html
     /// [`initialize`]: #tymethod.initialize
     async fn goto_implementation(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,6 +379,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// ```text
     /// InitializeParams::capabilities::text_document::type_definition::link_support
     /// ```
+    ///
     /// [`GotoDefinitionResponse::Link`]: https://docs.rs/lsp-types/0.70.2/lsp_types/request/enum.GotoDefinitionResponse.html#variant.Link
     /// [`initialize`]: #tymethod.initialize
     async fn goto_type_definition(
@@ -404,6 +405,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// ```text
     /// InitializeParams::capabilities::text_document::implementation::link_support
     /// ```
+    ///
     /// [`GotoImplementationResponse::Link`]: https://docs.rs/lsp-types/0.70.2/lsp_types/request/enum.GotoDefinitionResponse.html
     /// [`initialize`]: #tymethod.initialize
     async fn goto_implementation(

--- a/src/service.rs
+++ b/src/service.rs
@@ -133,14 +133,14 @@ mod tests {
     use tower_test::mock::Spawn;
 
     use super::*;
-    use crate::Printer;
+    use crate::Client;
 
     #[derive(Debug, Default)]
     struct Mock;
 
     #[async_trait]
     impl LanguageServer for Mock {
-        fn initialize(&self, _: &Printer, _: InitializeParams) -> Result<InitializeResult> {
+        fn initialize(&self, _: &Client, _: InitializeParams) -> Result<InitializeResult> {
             Ok(InitializeResult::default())
         }
 


### PR DESCRIPTION
### Added

* Implement routing of client responses back to the `Printer` (now renamed `Client`).
* Implement support for the following client requests:
  * `window/showMessageRequest`
  * `workspace/configuration`
  * `workspace/workspaceFolders`

### Changed

* Rename `Printer` to `Client`.
* Update `LanguageServer` trait method type signatures to reference `client` and `Client`.
* Increase minimum supported Rust version to 1.40.0.
* Rename `Client::send_notification()` to `Client::send_custom_notification()`. This is to avoid a name clash with a new internal method and to be more explicit during usage.
* Convert `workspace/applyEdit` request to `async fn` which returns an `ApplyWorkspaceEditResponse`.
* Improve compatibility notes for client/server requests added in a later LSP specification version.

### Fixed

* Clean up some incorrect or outdated doc comments.

Closes #13 and closes #128.

CC @icsaszar 