### PR TITLE
Implement textDocument/documentLink and documentLink/resolve

### DIFF
--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -128,6 +128,12 @@ pub trait LanguageServerCore {
     #[rpc(name = "codeLens/resolve", raw_params)]
     fn code_lens_resolve(&self, params: Params) -> BoxFuture<CodeLens>;
 
+    #[rpc(name = "textDocument/documentLink", raw_params)]
+    fn document_link(&self, params: Params) -> BoxFuture<Option<Vec<DocumentLink>>>;
+
+    #[rpc(name = "documentLink/resolve", raw_params)]
+    fn document_link_resolve(&self, params: Params) -> BoxFuture<DocumentLink>;
+
     #[rpc(name = "textDocument/formatting", raw_params)]
     fn formatting(&self, params: Params) -> BoxFuture<Option<Vec<TextEdit>>>;
 }
@@ -268,6 +274,8 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
     delegate_request!(code_action -> CodeActionRequest);
     delegate_request!(code_lens -> CodeLensRequest);
     delegate_request!(code_lens_resolve -> CodeLensResolve);
+    delegate_request!(document_link -> DocumentLinkRequest);
+    delegate_request!(document_link_resolve -> DocumentLinkResolve);
     delegate_request!(formatting -> Formatting);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,6 +513,32 @@ pub trait LanguageServer: Send + Sync + 'static {
         Err(Error::method_not_found())
     }
 
+    /// The [`textDocument/documentLink`] request is sent from the client to the server to request
+    /// the location of links in a document.
+    ///
+    /// A document link is a range in a text document that links to an internal or external
+    /// resource, like another text document or a web site.
+    ///
+    /// [`textDocument/documentLink`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentLink
+    async fn document_link(&self, params: DocumentLinkParams) -> Result<Option<Vec<DocumentLink>>> {
+        let _ = params;
+        error!("Got a textDocument/documentLink request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
+    /// The [`documentLink/resolve`] request is sent from the client to the server to resolve the
+    /// target of a given document link.
+    ///
+    /// A document link is a range in a text document that links to an internal or external
+    /// resource, like another text document or a web site.
+    ///
+    /// [`documentLink/resolve`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#documentLink_resolve
+    async fn document_link_resolve(&self, params: DocumentLink) -> Result<DocumentLink> {
+        let _ = params;
+        error!("Got a documentLink/resolve request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
     /// The [`textDocument/formatting`] request is sent from the client to the server to format a
     /// whole document.
     ///
@@ -664,6 +690,14 @@ impl<S: ?Sized + LanguageServer> LanguageServer for Box<S> {
 
     async fn code_lens_resolve(&self, params: CodeLens) -> Result<CodeLens> {
         (**self).code_lens_resolve(params).await
+    }
+
+    async fn document_link(&self, params: DocumentLinkParams) -> Result<Option<Vec<DocumentLink>>> {
+        (**self).document_link(params).await
+    }
+
+    async fn document_link_resolve(&self, params: DocumentLink) -> Result<DocumentLink> {
+        (**self).document_link_resolve(params).await
     }
 
     async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {


### PR DESCRIPTION
### Added

* Implement `textDocument/documentLink` server request.
* Implement `documentLink/resolve` server request.

Affects #10.