### PR TITLE
Implement textDocument/rename request

### DIFF
--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -136,6 +136,9 @@ pub trait LanguageServerCore {
 
     #[rpc(name = "textDocument/formatting", raw_params)]
     fn formatting(&self, params: Params) -> BoxFuture<Option<Vec<TextEdit>>>;
+
+    #[rpc(name = "textDocument/rename", raw_params)]
+    fn rename(&self, params: Params) -> BoxFuture<Option<WorkspaceEdit>>;
 }
 
 /// Wraps the language server backend and provides a `Printer` for sending notifications.
@@ -277,6 +280,7 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
     delegate_request!(document_link -> DocumentLinkRequest);
     delegate_request!(document_link_resolve -> DocumentLinkResolve);
     delegate_request!(formatting -> Formatting);
+    delegate_request!(rename -> Rename);
 }
 
 /// Error response returned for every request received before the server is initialized.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,6 +548,17 @@ pub trait LanguageServer: Send + Sync + 'static {
         error!("Got a textDocument/formatting request, but it is not implemented");
         Err(Error::method_not_found())
     }
+
+    /// The [`textDocument/rename`] request is sent from the client to the server to ask the server
+    /// to compute a workspace change so that the client can perform a workspace-wide rename of a
+    /// symbol.
+    ///
+    /// [`textDocument/rename`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting
+    async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
+        let _ = params;
+        error!("Got a textDocument/rename request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
 }
 
 #[async_trait]
@@ -702,5 +713,9 @@ impl<S: ?Sized + LanguageServer> LanguageServer for Box<S> {
 
     async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
         (**self).formatting(params).await
+    }
+
+    async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
+        (**self).rename(params).await
     }
 }


### PR DESCRIPTION
### Added

* Implement `textDocument/rename` server request.

Affects #10.