### PR TITLE
Implement textDocument/prepareRename request

### DIFF
--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -139,6 +139,9 @@ pub trait LanguageServerCore {
 
     #[rpc(name = "textDocument/rename", raw_params)]
     fn rename(&self, params: Params) -> BoxFuture<Option<WorkspaceEdit>>;
+
+    #[rpc(name = "textDocument/prepareRename", raw_params)]
+    fn prepare_rename(&self, params: Params) -> BoxFuture<Option<PrepareRenameResponse>>;
 }
 
 /// Wraps the language server backend and provides a `Printer` for sending notifications.
@@ -281,6 +284,7 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
     delegate_request!(document_link_resolve -> DocumentLinkResolve);
     delegate_request!(formatting -> Formatting);
     delegate_request!(rename -> Rename);
+    delegate_request!(prepare_rename -> PrepareRenameRequest);
 }
 
 /// Error response returned for every request received before the server is initialized.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -553,7 +553,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// to compute a workspace change so that the client can perform a workspace-wide rename of a
     /// symbol.
     ///
-    /// [`textDocument/rename`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting
+    /// [`textDocument/rename`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rename
     async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
         let _ = params;
         error!("Got a textDocument/rename request, but it is not implemented");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -559,6 +559,29 @@ pub trait LanguageServer: Send + Sync + 'static {
         error!("Got a textDocument/rename request, but it is not implemented");
         Err(Error::method_not_found())
     }
+
+    /// The [`textDocument/prepareRename`] request is sent from the client to the server to setup
+    /// and test the validity of a rename operation at a given location.
+    ///
+    /// [`textDocument/prepareRename`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_prepareRename
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.12.0 and requires client-side
+    /// support in order to be used. It can be returned if the client set the following field to
+    /// `true` in the [`initialize`] method:
+    ///
+    /// ```text
+    /// InitializeParams::capabilities::text_document::rename::prepare_support
+    /// ```
+    async fn prepare_rename(
+        &self,
+        params: TextDocumentPositionParams,
+    ) -> Result<Option<PrepareRenameResponse>> {
+        let _ = params;
+        error!("Got a textDocument/prepareRename request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
 }
 
 #[async_trait]
@@ -717,5 +740,12 @@ impl<S: ?Sized + LanguageServer> LanguageServer for Box<S> {
 
     async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
         (**self).rename(params).await
+    }
+
+    async fn prepare_rename(
+        &self,
+        params: TextDocumentPositionParams,
+    ) -> Result<Option<PrepareRenameResponse>> {
+        (**self).prepare_rename(params).await
     }
 }


### PR DESCRIPTION
### Added

* Implement `textDocument/prepareRename` server request.

### Fixed

* Fix incorrect link in `LanguageServer::rename()` doc comment (introduced in #137).

Affects #10.