### PR TITLE
Swap order of document_highlight() and document_symbol()

### DIFF
--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -113,11 +113,11 @@ pub trait LanguageServerCore {
     #[rpc(name = "textDocument/implementation", raw_params)]
     fn goto_implementation(&self, params: Params) -> BoxFuture<Option<GotoImplementationResponse>>;
 
-    #[rpc(name = "textDocument/documentSymbol", raw_params)]
-    fn document_symbol(&self, params: Params) -> BoxFuture<Option<DocumentSymbolResponse>>;
-
     #[rpc(name = "textDocument/documentHighlight", raw_params)]
     fn document_highlight(&self, params: Params) -> BoxFuture<Option<Vec<DocumentHighlight>>>;
+
+    #[rpc(name = "textDocument/documentSymbol", raw_params)]
+    fn document_symbol(&self, params: Params) -> BoxFuture<Option<DocumentSymbolResponse>>;
 
     #[rpc(name = "textDocument/codeAction", raw_params)]
     fn code_action(&self, params: Params) -> BoxFuture<Option<CodeActionResponse>>;
@@ -275,8 +275,8 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
     delegate_request!(goto_definition -> GotoDefinition);
     delegate_request!(goto_type_definition -> GotoTypeDefinition);
     delegate_request!(goto_implementation -> GotoImplementation);
-    delegate_request!(document_symbol -> DocumentSymbolRequest);
     delegate_request!(document_highlight -> DocumentHighlightRequest);
+    delegate_request!(document_symbol -> DocumentSymbolRequest);
     delegate_request!(code_action -> CodeActionRequest);
     delegate_request!(code_lens -> CodeLensRequest);
     delegate_request!(code_lens_resolve -> CodeLensResolve);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,6 +417,25 @@ pub trait LanguageServer: Send + Sync + 'static {
         Err(Error::method_not_found())
     }
 
+    /// The [`textDocument/documentHighlight`] request is sent from the client to the server to
+    /// resolve appropriate highlights for a given text document position.
+    ///
+    /// For programming languages, this usually highlights all textual references to the symbol
+    /// scoped to this file.
+    ///
+    /// This request differs slightly from `textDocument/references` in that this one is allowed to
+    /// be more fuzzy.
+    ///
+    /// [`textDocument/documentHighlight`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentHighlight
+    async fn document_highlight(
+        &self,
+        params: TextDocumentPositionParams,
+    ) -> Result<Option<Vec<DocumentHighlight>>> {
+        let _ = params;
+        error!("Got a textDocument/documentHighlight request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
     /// The [`textDocument/documentSymbol`] request is sent from the client to the server to
     /// retrieve all symbols found in a given text document.
     ///
@@ -437,25 +456,6 @@ pub trait LanguageServer: Send + Sync + 'static {
     ) -> Result<Option<DocumentSymbolResponse>> {
         let _ = params;
         error!("Got a textDocument/documentSymbol request, but it is not implemented");
-        Err(Error::method_not_found())
-    }
-
-    /// The [`textDocument/documentHighlight`] request is sent from the client to the server to
-    /// resolve appropriate highlights for a given text document position.
-    ///
-    /// For programming languages, this usually highlights all textual references to the symbol
-    /// scoped to this file.
-    ///
-    /// This request differs slightly from `textDocument/references` in that this one is allowed to
-    /// be more fuzzy.
-    ///
-    /// [`textDocument/documentHighlight`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentHighlight
-    async fn document_highlight(
-        &self,
-        params: TextDocumentPositionParams,
-    ) -> Result<Option<Vec<DocumentHighlight>>> {
-        let _ = params;
-        error!("Got a textDocument/documentHighlight request, but it is not implemented");
         Err(Error::method_not_found())
     }
 
@@ -700,18 +700,18 @@ impl<S: ?Sized + LanguageServer> LanguageServer for Box<S> {
         (**self).goto_implementation(params).await
     }
 
-    async fn document_symbol(
-        &self,
-        params: DocumentSymbolParams,
-    ) -> Result<Option<DocumentSymbolResponse>> {
-        (**self).document_symbol(params).await
-    }
-
     async fn document_highlight(
         &self,
         params: TextDocumentPositionParams,
     ) -> Result<Option<Vec<DocumentHighlight>>> {
         (**self).document_highlight(params).await
+    }
+
+    async fn document_symbol(
+        &self,
+        params: DocumentSymbolParams,
+    ) -> Result<Option<DocumentSymbolResponse>> {
+        (**self).document_symbol(params).await
     }
 
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {


### PR DESCRIPTION
### Changed

* Swap order of `document_highlight()` and `document_symbol()` trait methods.

It seems that the ordering of these two methods is inconsistent with their definitions in the official Language Server Protocol specification. This is not a breaking change and is purely cosmetic.