### PR TITLE
Implement textDocument/references request

### DIFF
--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -113,6 +113,9 @@ pub trait LanguageServerCore {
     #[rpc(name = "textDocument/implementation", raw_params)]
     fn goto_implementation(&self, params: Params) -> BoxFuture<Option<GotoImplementationResponse>>;
 
+    #[rpc(name = "textDocument/references", raw_params)]
+    fn references(&self, params: Params) -> BoxFuture<Option<Vec<Location>>>;
+
     #[rpc(name = "textDocument/documentHighlight", raw_params)]
     fn document_highlight(&self, params: Params) -> BoxFuture<Option<Vec<DocumentHighlight>>>;
 
@@ -275,6 +278,7 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
     delegate_request!(goto_definition -> GotoDefinition);
     delegate_request!(goto_type_definition -> GotoTypeDefinition);
     delegate_request!(goto_implementation -> GotoImplementation);
+    delegate_request!(references -> References);
     delegate_request!(document_highlight -> DocumentHighlightRequest);
     delegate_request!(document_symbol -> DocumentSymbolRequest);
     delegate_request!(code_action -> CodeActionRequest);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,6 +417,16 @@ pub trait LanguageServer: Send + Sync + 'static {
         Err(Error::method_not_found())
     }
 
+    /// The [`textDocument/references`] request is sent from the client to the server to resolve
+    /// project-wide references for the symbol denoted by the given text document position.
+    ///
+    /// [`textDocument/references`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
+    async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {
+        let _ = params;
+        error!("Got a textDocument/references request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
     /// The [`textDocument/documentHighlight`] request is sent from the client to the server to
     /// resolve appropriate highlights for a given text document position.
     ///
@@ -698,6 +708,10 @@ impl<S: ?Sized + LanguageServer> LanguageServer for Box<S> {
         params: TextDocumentPositionParams,
     ) -> Result<Option<GotoImplementationResponse>> {
         (**self).goto_implementation(params).await
+    }
+
+    async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {
+        (**self).references(params).await
     }
 
     async fn document_highlight(


### PR DESCRIPTION
### Added

* Implement `textDocument/references` server request.

Affects #10.