### PR TITLE
Use Ordering::Relaxed when incrementing client request ID

### DIFF
--- a/src/delegate/client.rs
+++ b/src/delegate/client.rs
@@ -289,7 +289,7 @@ impl Client {
         R::Params: Serialize,
         R::Result: DeserializeOwned,
     {
-        let id = self.request_id.fetch_add(1, Ordering::SeqCst);
+        let id = self.request_id.fetch_add(1, Ordering::Relaxed);
         let message = make_request::<R>(id, params);
 
         if self.sender.clone().send(message).await.is_err() {


### PR DESCRIPTION
### Changed

* Use `Ordering::Relaxed` when incrementing client request ID.

The relevant chapter of the [Nomicon] states that `Ordering::Relaxed` should be safe to use for incrementing an atomic counter as long as the datum isn't being used to communicate between threads operating on shared memory.

In our case, we are using it to generate unique request IDs, so this should be safe and would provide a performance improvement on platforms with weak ordering semantics.

[Nomicon]: https://doc.rust-lang.org/nomicon/atomics.html#relaxed