### PR TITLE
Fix doc comment links to LanguageServer::initialize()

### DIFF
--- a/src/delegate/client.rs
+++ b/src/delegate/client.rs
@@ -188,7 +188,7 @@ impl Client {
     /// InitializeParams::capabilities::workspace::workspace_folders
     /// ```
     ///
-    /// [`LanguageServer::initialize`]: #tymethod.initialize
+    /// [`LanguageServer::initialize`]: ./trait.LanguageServer.html#tymethod.initialize
     ///
     /// # Initialization
     ///
@@ -224,7 +224,7 @@ impl Client {
     /// InitializeParams::capabilities::workspace::configuration
     /// ```
     ///
-    /// [`LanguageServer::initialize`]: #tymethod.initialize
+    /// [`LanguageServer::initialize`]: ./trait.LanguageServer.html#tymethod.initialize
     ///
     /// # Initialization
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -615,6 +615,8 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// ```text
     /// InitializeParams::capabilities::text_document::rename::prepare_support
     /// ```
+    ///
+    /// [`initialize`]: #tymethod.initialize
     async fn prepare_rename(
         &self,
         params: TextDocumentPositionParams,


### PR DESCRIPTION
### Fixed

* Fix link to `initialize()` method in `prepare_rename()`.
* Fix links to `initialize()` method in `Client`.