### PR TITLE
Fix compatibility documentation

### DIFF
--- a/src/delegate/client.rs
+++ b/src/delegate/client.rs
@@ -180,15 +180,7 @@ impl Client {
     ///
     /// # Compatibility
     ///
-    /// This request was introduced in specification version 3.6.0 and requires client-side support
-    /// in order to be used. It can only be called if the client set the following field to `true`
-    /// in the [`LanguageServer::initialize`] method:
-    ///
-    /// ```text
-    /// InitializeParams::capabilities::workspace::workspace_folders
-    /// ```
-    ///
-    /// [`LanguageServer::initialize`]: ./trait.LanguageServer.html#tymethod.initialize
+    /// This request was introduced in specification version 3.6.0.
     ///
     /// # Initialization
     ///

--- a/src/delegate/client.rs
+++ b/src/delegate/client.rs
@@ -178,16 +178,16 @@ impl Client {
     ///
     /// [`workspace/workspaceFolders`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_workspaceFolders
     ///
-    /// # Compatibility
-    ///
-    /// This request was introduced in specification version 3.6.0.
-    ///
     /// # Initialization
     ///
     /// If the request is sent to client before the server has been initialized, this will
     /// immediately return `Err` with JSON-RPC error code `-32002` ([read more]).
     ///
     /// [read more]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.6.0.
     pub async fn workspace_folders(&self) -> Result<Option<Vec<WorkspaceFolder>>> {
         self.send_request_initialized::<WorkspaceFoldersRequest>(())
             .await
@@ -206,16 +206,16 @@ impl Client {
     ///
     /// [`workspace/configuration`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_configuration
     ///
-    /// # Compatibility
-    ///
-    /// This request was introduced in specification version 3.6.0.
-    ///
     /// # Initialization
     ///
     /// If the request is sent to client before the server has been initialized, this will
     /// immediately return `Err` with JSON-RPC error code `-32002` ([read more]).
     ///
     /// [read more]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.6.0.
     pub async fn configuration(&self, items: Vec<ConfigurationItem>) -> Result<Vec<Value>> {
         self.send_request_initialized::<WorkspaceConfiguration>(ConfigurationParams { items })
             .await

--- a/src/delegate/client.rs
+++ b/src/delegate/client.rs
@@ -208,15 +208,7 @@ impl Client {
     ///
     /// # Compatibility
     ///
-    /// This request was introduced in specification version 3.6.0 and requires client-side support
-    /// in order to be used. It can only be called if the client set the following field to `true`
-    /// in the [`LanguageServer::initialize`] method:
-    ///
-    /// ```text
-    /// InitializeParams::capabilities::workspace::configuration
-    /// ```
-    ///
-    /// [`LanguageServer::initialize`]: ./trait.LanguageServer.html#tymethod.initialize
+    /// This request was introduced in specification version 3.6.0.
     ///
     /// # Initialization
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,6 +320,8 @@ pub trait LanguageServer: Send + Sync + 'static {
     ///
     /// # Compatibility
     ///
+    /// This request was introduced in specification version 3.14.0.
+    ///
     /// The [`GotoDefinitionResponse::Link`] return value was introduced in specification version
     /// 3.14.0 and requires client-side support in order to be used. It can be returned if the
     /// client set the following field to `true` in the [`initialize`] method:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,6 +374,8 @@ pub trait LanguageServer: Send + Sync + 'static {
     ///
     /// # Compatibility
     ///
+    /// This request was introduced in specification version 3.6.0.
+    ///
     /// The [`GotoDefinitionResponse::Link`] return value was introduced in specification version
     /// 3.14.0 and requires client-side support in order to be used. It can be returned if the
     /// client set the following field to `true` in the [`initialize`] method:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,6 +402,8 @@ pub trait LanguageServer: Send + Sync + 'static {
     ///
     /// # Compatibility
     ///
+    /// This request was introduced in specification version 3.6.0.
+    ///
     /// The [`GotoImplementationResponse::Link`] return value was introduced in specification
     /// version 3.14.0 and requires client-side support in order to be used. It can be returned if
     /// the client set the following field to `true` in the [`initialize`] method:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -590,9 +590,10 @@ pub trait LanguageServer: Send + Sync + 'static {
     ///
     /// # Compatibility
     ///
-    /// This request was introduced in specification version 3.6.0 and requires client-side support
-    /// in order to be used. However, it has no special capabilities and registration options since
-    /// it is send as a resolve request for the [`textDocument/documentColor`] request.
+    /// This request was introduced in specification version 3.6.0.
+    ///
+    /// This request has no special capabilities and registration options since it is sent as a
+    /// resolve request for the [`textDocument/documentColor`] request.
     ///
     /// [`textDocument/documentColor`]: #tymethod.document_color
     async fn color_presentation(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -539,6 +539,18 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// resource, like another text document or a web site.
     ///
     /// [`textDocument/documentLink`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentLink
+    ///
+    /// # Compatibility
+    ///
+    /// The [`DocumentLink::tooltip`] field was introduced in specification version 3.15.0 and
+    /// requires client-side support in order to be used. It can be returned if the client set the
+    /// following field to `true` in the [`initialize`] method:
+    ///
+    /// ```text
+    /// InitializeParams::capabilities::text_document::document_link::tooltip_support
+    /// ```
+    ///
+    /// [`initialize`]: #tymethod.initialize
     async fn document_link(&self, params: DocumentLinkParams) -> Result<Option<Vec<DocumentLink>>> {
         let _ = params;
         error!("Got a textDocument/documentLink request, but it is not implemented");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -583,15 +583,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     ///
     /// # Compatibility
     ///
-    /// This request was introduced in specification version 3.6.0 and requires client-side support
-    /// in order to be used. It can be returned if the client set the following field to
-    /// `true` in the [`initialize`] method:
-    ///
-    /// ```text
-    /// InitializeParams::capabilities::text_document::color_provider
-    /// ```
-    ///
-    /// [`initialize`]: #tymethod.initialize
+    /// This request was introduced in specification version 3.6.0.
     async fn document_color(&self, params: DocumentColorParams) -> Result<Vec<ColorInformation>> {
         let _ = params;
         error!("Got a textDocument/documentColor request, but it is not implemented");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -669,15 +669,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     ///
     /// # Compatibility
     ///
-    /// This request was introduced in specification version 3.12.0 and requires client-side
-    /// support in order to be used. It can be returned if the client set the following field to
-    /// `true` in the [`initialize`] method:
-    ///
-    /// ```text
-    /// InitializeParams::capabilities::text_document::rename::prepare_support
-    /// ```
-    ///
-    /// [`initialize`]: #tymethod.initialize
+    /// This request was introduced in specification version 3.12.0.
     async fn prepare_rename(
         &self,
         params: TextDocumentPositionParams,


### PR DESCRIPTION
### Added

* Add compatibility notes for `goto_declaration()`.

### Changed

* Update compatibility notes for `color_presentation()`.
* Update compatibility notes for `goto_type_definition()`.
* Update compatibility notes for `goto_implementation()`.
* Update compatibility notes for `document_link()`.
* Move `Client` compatibility notes to bottom.

### Fixed

* Fix compatibility notes for `document_color()`.
* Fix compatibility notes for `prepare_rename()`.
* Fix compatibility notes for `Client::workspace_folders()`.
* Fix compatibility notes for `Client::workspace_configuration()`.