### PR TITLE
Fix documentation for textDocument/foldingRange request

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -682,6 +682,8 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// The [`textDocument/foldingRange`] request is sent from the client to the server to return
     /// all folding ranges found in a given text document.
     ///
+    /// [`textDocument/foldingRange`]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_foldingRange
+    ///
     /// # Compatibility
     ///
     /// This request was introduced in specification version 3.10.0.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -684,8 +684,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     ///
     /// # Compatibility
     ///
-    /// This request was introduced in specification version 3.10.0 and requires client-side
-    /// support in order to be used.
+    /// This request was introduced in specification version 3.10.0.
     async fn folding_range(&self, params: FoldingRangeParams) -> Result<Option<Vec<FoldingRange>>> {
         let _ = params;
         error!("Got a textDocument/foldingRange request, but it is not implemented");


### PR DESCRIPTION
### Added

* Add missing link to `folding_range()` docs.

### Removed

* Remove redundant sentence clause in `folding_range()`.

Follow-up to #156.