### PR TITLE
Add expect() message to sender.send()

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -110,7 +110,7 @@ impl Service<Incoming> for LspService {
             if let Incoming::Response(res) = request {
                 let mut sender = self.sender.clone();
                 Box::pin(async move {
-                    sender.send(res).await.unwrap();
+                    sender.send(res).await.expect("LspService already dropped");
                     Ok(None)
                 })
             } else {


### PR DESCRIPTION
### Added

* Add `expect()` message to `sender.send()` inside `LspService::call()`.

This panic message was added just in case the request future is polled after the `LspService` that produced it has been dropped.