### PR TITLE
Implement textDocument/willSaveWaitUntil request

### DIFF
--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -86,6 +86,9 @@ pub trait LanguageServerCore {
     #[rpc(name = "textDocument/willSave", raw_params)]
     fn will_save(&self, params: Params);
 
+    #[rpc(name = "textDocument/willSaveWaitUntil", raw_params)]
+    fn will_save_wait_until(&self, params: Params) -> BoxFuture<Option<Vec<TextEdit>>>;
+
     #[rpc(name = "textDocument/didSave", raw_params)]
     fn did_save(&self, params: Params);
 
@@ -291,6 +294,7 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
     delegate_notification!(did_open -> DidOpenTextDocument);
     delegate_notification!(did_change -> DidChangeTextDocument);
     delegate_notification!(will_save -> WillSaveTextDocument);
+    delegate_request!(will_save_wait_until -> WillSaveWaitUntil);
     delegate_notification!(did_save -> DidSaveTextDocument);
     delegate_notification!(did_close -> DidCloseTextDocument);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,23 @@ pub trait LanguageServer: Send + Sync + 'static {
         warn!("Got a textDocument/willSave notification, but it is not implemented");
     }
 
+    /// The [`textDocument/willSaveWaitUntil`] request is sent from the client to the server before
+    /// the document is actually saved.
+    ///
+    /// The request can return an array of `TextEdit`s which will be applied to the text document
+    /// before it is saved.
+    ///
+    /// Please note that clients might drop results if computing the text edits took too long or if
+    /// a server constantly fails on this request. This is done to keep the save fast and reliable.
+    async fn will_save_wait_until(
+        &self,
+        params: WillSaveTextDocumentParams,
+    ) -> Result<Option<Vec<TextEdit>>> {
+        let _ = params;
+        error!("Got a textDocument/willSaveWaitUntil request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
     /// The [`textDocument/didSave`] notification is sent from the client to the server when the
     /// document was saved in the client.
     ///
@@ -756,6 +773,13 @@ impl<S: ?Sized + LanguageServer> LanguageServer for Box<S> {
 
     async fn will_save(&self, client: &Client, params: WillSaveTextDocumentParams) {
         (**self).will_save(client, params).await;
+    }
+
+    async fn will_save_wait_until(
+        &self,
+        params: WillSaveTextDocumentParams,
+    ) -> Result<Option<Vec<TextEdit>>> {
+        (**self).will_save_wait_until(params).await
     }
 
     async fn did_save(&self, client: &Client, params: DidSaveTextDocumentParams) {


### PR DESCRIPTION
### Added

* Implement `textDocument/willSaveWaitUntil` server request.

Affects #10.