### PR TITLE
Fix JSON-RPC delegate for textDocument/foldingRange

### DIFF
--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -166,7 +166,7 @@ pub trait LanguageServerCore {
     #[rpc(name = "textDocument/prepareRename", raw_params)]
     fn prepare_rename(&self, params: Params) -> BoxFuture<Option<PrepareRenameResponse>>;
 
-    #[rpc(name = "textDocument/prepareRename", raw_params)]
+    #[rpc(name = "textDocument/foldingRange", raw_params)]
     fn folding_range(&self, params: Params) -> BoxFuture<Option<Vec<FoldingRange>>>;
 
     #[rpc(name = "textDocument/selectionRange", raw_params)]


### PR DESCRIPTION
### Fixed

* Fix JSON-RPC delegate for `textDocument/foldingRange` introduced in #156.

This fix would technically warrant a new 0.9.2 release, but since we already merged #162 which contains breaking changes, we will have to delay until 0.10.0.

Closes #10.