### PR TITLE
Re-export common jsonrpc-core types in 'jsonrpc' module

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ consists of three parts:
 ## Example
 
 ```rust
-use jsonrpc_core::Result;
+use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 

--- a/examples/custom_notification.rs
+++ b/examples/custom_notification.rs
@@ -1,6 +1,6 @@
-use jsonrpc_core::{Error, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tower_lsp::jsonrpc::{Error, Result};
 use tower_lsp::lsp_types::notification::Notification;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,5 +1,5 @@
-use jsonrpc_core::Result;
 use serde_json::Value;
+use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -1,0 +1,9 @@
+//! Re-exports of common [`jsonrpc-core`](https://docs.rs/jsonrpc-core) types for convenience.
+
+pub use jsonrpc_core::error::{Error, ErrorCode};
+pub use jsonrpc_core::id::Id;
+pub use jsonrpc_core::params::Params;
+pub use jsonrpc_core::request::{MethodCall, Notification};
+pub use jsonrpc_core::response::{Failure, Output, Success};
+pub use jsonrpc_core::version::Version;
+pub use jsonrpc_core::Result;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,14 +5,10 @@
 //! # Example
 //!
 //! ```rust
-//! # use std::future::Future;
-//! #
-//! # use jsonrpc_core::Result;
-//! # use serde_json::Value;
-//! # use tower_lsp::lsp_types::request::{GotoDefinitionResponse, GotoImplementationResponse};
-//! # use tower_lsp::lsp_types::*;
-//! # use tower_lsp::{LanguageServer, LspService, Client, Server};
-//! #
+//! use tower_lsp::jsonrpc::Result;
+//! use tower_lsp::lsp_types::*;
+//! use tower_lsp::{LanguageServer, LspService, Client, Server};
+//!
 //! #[derive(Debug, Default)]
 //! struct Backend;
 //!
@@ -78,6 +74,8 @@ use log::{error, warn};
 use lsp_types::request::{GotoDefinitionResponse, GotoImplementationResponse};
 use lsp_types::*;
 use serde_json::Value;
+
+pub mod jsonrpc;
 
 mod codec;
 mod delegate;


### PR DESCRIPTION
### Added

* Re-export common `jsonrpc-core` types in `jsonrpc` module.

### Changed

* Show imports in `lib.rs` example server.

Closes #108.