### PR TITLE
Support for proposed API requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ tower-service = "0.3"
 env_logger = "0.7"
 tokio = { version = "0.2", features = ["io-std", "macros", "test-util"] }
 tower-test = "0.3"
+
+[features]
+proposed = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,5 @@ tokio = { version = "0.2", features = ["io-std", "macros", "test-util"] }
 tower-test = "0.3"
 
 [features]
-proposed = []
+default = ["proposed"]
+proposed = ["lsp-types/proposed"]

--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -171,6 +171,31 @@ pub trait LanguageServerCore {
 
     #[rpc(name = "textDocument/selectionRange", raw_params)]
     fn selection_range(&self, params: Params) -> BoxFuture<Option<Vec<SelectionRange>>>;
+
+    #[rpc(name = "textDocument/prepareCallHierarchy", raw_params)]
+    fn prepare_call_hierarchy(&self, params: Params) -> BoxFuture<Option<Vec<CallHierarchyItem>>>;
+
+    #[rpc(name = "callHierarchy/incomingCalls", raw_params)]
+    fn call_hierarchy_incoming_calls(
+        &self,
+        params: Params,
+    ) -> BoxFuture<Option<Vec<CallHierarchyIncomingCall>>>;
+
+    #[rpc(name = "callHierarchy/incomingCalls", raw_params)]
+    fn call_hierarchy_outgoing_calls(
+        &self,
+        params: Params,
+    ) -> BoxFuture<Option<Vec<CallHierarchyOutgoingCall>>>;
+
+    #[rpc(name = "textDocument/semanticTokens", raw_params)]
+    fn semantic_tokens(&self, params: Params) -> BoxFuture<Option<SemanticTokensResult>>;
+
+    #[rpc(name = "textDocument/semanticTokens/edits", raw_params)]
+    fn semantic_tokens_edits(&self, params: Params) -> BoxFuture<Option<SemanticTokensEditResult>>;
+
+    #[rpc(name = "textDocument/semanticTokens/range", raw_params)]
+    fn semantic_tokens_range(&self, params: Params)
+        -> BoxFuture<Option<SemanticTokensRangeResult>>;
 }
 
 /// Wraps the language server backend and provides a `Printer` for sending notifications.
@@ -326,6 +351,12 @@ impl<T: LanguageServer> LanguageServerCore for Delegate<T> {
     delegate_request!(prepare_rename -> PrepareRenameRequest);
     delegate_request!(folding_range -> FoldingRangeRequest);
     delegate_request!(selection_range -> SelectionRangeRequest);
+    delegate_request!(prepare_call_hierarchy -> CallHierarchyPrepare);
+    delegate_request!(call_hierarchy_incoming_calls -> CallHierarchyIncomingCalls);
+    delegate_request!(call_hierarchy_outgoing_calls -> CallHierarchyOutgoingCalls);
+    delegate_request!(semantic_tokens -> SemanticTokensRequest);
+    delegate_request!(semantic_tokens_edits -> SemanticTokensEditsRequest);
+    delegate_request!(semantic_tokens_range -> SemanticTokensRangeRequest);
 }
 
 /// Error response returned for every request received before the server is initialized.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -731,6 +731,90 @@ pub trait LanguageServer: Send + Sync + 'static {
         error!("Got a textDocument/selectionRange request, but it is not implemented");
         Err(Error::method_not_found())
     }
+
+    /// [`textDocument/prepareCallHierarchy`]: https://github.com/microsoft/vscode-languageserver-node/blob/master/protocol/src/protocol.callHierarchy.proposed.ts
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    async fn prepare_call_hierarchy(
+        &self,
+        params: CallHierarchyPrepareParams,
+    ) -> Result<Option<Vec<CallHierarchyItem>>> {
+        let _ = params;
+        error!("Got a textDocument/prepareCallHierarchy request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
+    /// [`callHierarchy/incomingCalls`]: https://github.com/microsoft/vscode-languageserver-node/blob/master/protocol/src/protocol.callHierarchy.proposed.ts
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    async fn call_hierarchy_incoming_calls(
+        &self,
+        params: CallHierarchyIncomingCallsParams,
+    ) -> Result<Option<Vec<CallHierarchyIncomingCall>>> {
+        let _ = params;
+        error!("Got a callHierarchy/incomingCalls request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
+    /// [`callHierarchy/outgoingCalls`]: https://github.com/microsoft/vscode-languageserver-node/blob/master/protocol/src/protocol.callHierarchy.proposed.ts
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    async fn call_hierarchy_outgoing_calls(
+        &self,
+        params: CallHierarchyOutgoingCallsParams,
+    ) -> Result<Option<Vec<CallHierarchyOutgoingCall>>> {
+        let _ = params;
+        error!("Got a callHierarchy/outgoingCalls request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
+    /// [`textDocument/semanticTokens`]: https://github.com/microsoft/vscode-languageserver-node/blob/master/protocol/src/protocol.semanticTokens.proposed.ts
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    async fn semantic_tokens(
+        &self,
+        params: SemanticTokensParams,
+    ) -> Result<Option<SemanticTokensResult>> {
+        let _ = params;
+        error!("Got a textDocument/semanticTokens request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
+    /// [`textDocument/semanticTokens/edits`]: https://github.com/microsoft/vscode-languageserver-node/blob/master/protocol/src/protocol.semanticTokens.proposed.ts
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    async fn semantic_tokens_edits(
+        &self,
+        params: SemanticTokensEditsParams,
+    ) -> Result<Option<SemanticTokensEditResult>> {
+        let _ = params;
+        error!("Got a textDocument/semanticTokens/edits request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
+    /// [`textDocument/semanticTokens/range`]: https://github.com/microsoft/vscode-languageserver-node/blob/master/protocol/src/protocol.semanticTokens.proposed.ts
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    async fn semantic_tokens_range(
+        &self,
+        params: SemanticTokensRangeParams,
+    ) -> Result<Option<SemanticTokensRangeResult>> {
+        let _ = params;
+        error!("Got a textDocument/semanticTokens/range request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
This PR adds support for proposed API requests.

I ran into some issues trying to put these behind a `#[cfg(feature = "proposed")]` and didn't have time to investigate further so I left those off for now and just enabled `"proposed"` for `lsp-types` by default so that the PR compiles (this should be fixed though).

It seems like there is some problematic interaction with the use of `#[rpc(...` which I don't know much about. Maybe you have some ideas?

This also addresses #146, but the actual requests that are implemented now seem to have changed and the `textDocument/semanticHighlight` mentioned in that issue is no longer used. See the comments for further details. 