### PR TITLE
Prepare release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.10.0] - 2020-03-19
+
+### Added
+
+* Implement support for the following client-to-server messages:
+  * `textDocument/willSaveWaitUntil`
+  * `textDocument/selectionRange`
+* Re-export useful `jsonrpc-core` types in a new `jsonrpc` module (PR #169).
+
+### Changed
+
+* Update `lsp-types` crate from 0.70 to 0.73 (PR #162).
+
+### Fixed
+
+* Fix JSON-RPC delegate for `textDocument/foldingRange` (PR #167).
+
 ## [0.9.1] - 2020-03-07
 
 ### Added
@@ -250,7 +267,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * `textDocument/hover`
   * `textDocument/documentHighlight`
 
-[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.7.0...v0.8.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 edition = "2018"
 description = "Language Server Protocol implementation based on Tower"


### PR DESCRIPTION
### Changed

* Update `CHANGELOG.md`.
* Bump crate version to 0.10.0.