### PR TITLE
Pass client to LanguageServer methods by Arc

### DIFF
--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -182,7 +182,7 @@ pub struct Delegate<T> {
     //
     // https://github.com/ebkalderon/tower-lsp/issues/58
     server: Arc<T>,
-    client: Arc<Client>,
+    client: Client,
     initialized: Arc<AtomicBool>,
 }
 
@@ -197,7 +197,7 @@ impl<T: LanguageServer> Delegate<T> {
         let initialized = Arc::new(AtomicBool::new(false));
         let delegate = Delegate {
             server: Arc::new(server),
-            client: Arc::new(Client::new(request_tx, response_rx, initialized.clone())),
+            client: Client::new(request_tx, response_rx, initialized.clone()),
             initialized,
         };
 


### PR DESCRIPTION
This PR changes the method signatures for `LanguageServer` so that client is passed in as `Arc<Client>` rather than `&Client`.

I'm not sure if you should merge this but it was easy enough to make the change so I figured I'd put this together rather than creating a separate issue about it first.

The reason I've made this change is because in a language server I am working on which uses this crate, I've found the need to be able to send notifications back to `client` from a separate thread of control (e.g., a diagnostics collector that runs in the background).

Basically what happens is when I get a `textDocument/didOpen` or `textDocument/didChange`, I do some work, then eventually fire a message off to a `tokio::sync::watch` channel to notify other components of the server that something has changed.

Some of those components might need to send a notification back through `client`, such as a diagnostic or popup message.

With the current design of `tower-lsp`, there doesn't seem to be an easy way to do this. I can't send `Client` along the `tokio::sync::watch` channel because I only have `&Client` and `Client` doesn't implement `Clone`.

It does seem possible to work around this limitation without using `Arc`, e.g., by implementing an additional layer of bidirectional messaging between components. But using `Arc` seems simpler and allows for a cleaner separation of functionality.

What do you think about this change?