### PR TITLE
Generalize LanguageServer impl to support Arc<S>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -734,7 +734,11 @@ pub trait LanguageServer: Send + Sync + 'static {
 }
 
 #[async_trait]
-impl<S: ?Sized + LanguageServer> LanguageServer for Box<S> {
+impl<T, S> LanguageServer for T
+where
+    T: std::ops::Deref<Target = S> + Send + Sync + 'static,
+    S: ?Sized + LanguageServer,
+{
     fn initialize(&self, client: &Client, params: InitializeParams) -> Result<InitializeResult> {
         (**self).initialize(client, params)
     }


### PR DESCRIPTION
This PR generalizes the derived `LanguageServer` implementation to support additional types with `Deref<Target = S>`, such as `Arc<S>`.