### PR TITLE
Add #[must_use] to MessageStream

### DIFF
--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -33,6 +33,7 @@ pub type MessageSender = Sender<Output>;
 
 /// Stream of messages produced by the language server.
 #[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
 pub struct MessageStream(Receiver<String>);
 
 impl Stream for MessageStream {


### PR DESCRIPTION
### Changed

* Add `#[must_use]` to `MessageStream`, making it obvious that the stream must be polled.