### PR TITLE
Prepare release 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.10.1] - 2020-04-29
+
+### Changed
+
+* Implement `Clone` for `Client` so it can be safely passed to functions
+  expecting `'static` values.
+* Mark `MessageStream` as `#[must_use]`.
+
 ## [0.10.0] - 2020-03-19
 
 ### Added
@@ -267,7 +275,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * `textDocument/hover`
   * `textDocument/documentHighlight`
 
-[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.10.1...HEAD
+[0.10.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.8.0...v0.9.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 edition = "2018"
 description = "Language Server Protocol implementation based on Tower"


### PR DESCRIPTION
### Changed

* Update `CHANGELOG.md`.
* Bump crate version to 0.10.1.