### PR TITLE
Make LanguageServer::initialize() asynchronous

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ struct Backend;
 
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
-    fn initialize(&self, _: &Client, _: InitializeParams) -> Result<InitializeResult> {
+    async fn initialize(&self, _: &Client, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult::default())
     }
 

--- a/examples/custom_notification.rs
+++ b/examples/custom_notification.rs
@@ -33,7 +33,7 @@ struct Backend;
 
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
-    fn initialize(&self, _: &Client, _: InitializeParams) -> Result<InitializeResult> {
+    async fn initialize(&self, _: &Client, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {
             server_info: None,
             capabilities: ServerCapabilities {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -8,7 +8,7 @@ struct Backend;
 
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
-    fn initialize(&self, _: &Client, _: InitializeParams) -> Result<InitializeResult> {
+    async fn initialize(&self, _: &Client, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {
             server_info: None,
             capabilities: ServerCapabilities {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! #[tower_lsp::async_trait]
 //! impl LanguageServer for Backend {
-//!     fn initialize(&self, _: &Client, _: InitializeParams) -> Result<InitializeResult> {
+//!     async fn initialize(&self, _: &Client, _: InitializeParams) -> Result<InitializeResult> {
 //!         Ok(InitializeResult::default())
 //!     }
 //!
@@ -100,7 +100,11 @@ pub trait LanguageServer: Send + Sync + 'static {
     ///
     /// This method is guaranteed to only execute once. If the client sends this request to the
     /// server again, the server will respond with JSON-RPC error code `-32600` (invalid request).
-    fn initialize(&self, client: &Client, params: InitializeParams) -> Result<InitializeResult>;
+    async fn initialize(
+        &self,
+        client: &Client,
+        params: InitializeParams,
+    ) -> Result<InitializeResult>;
 
     /// The [`initialized`] notification is sent from the client to the server after the client
     /// received the result of the initialize request but before the client sends anything else.
@@ -735,8 +739,12 @@ pub trait LanguageServer: Send + Sync + 'static {
 
 #[async_trait]
 impl<S: ?Sized + LanguageServer> LanguageServer for Box<S> {
-    fn initialize(&self, client: &Client, params: InitializeParams) -> Result<InitializeResult> {
-        (**self).initialize(client, params)
+    async fn initialize(
+        &self,
+        client: &Client,
+        params: InitializeParams,
+    ) -> Result<InitializeResult> {
+        (**self).initialize(client, params).await
     }
 
     async fn initialized(&self, client: &Client, params: InitializedParams) {

--- a/src/service.rs
+++ b/src/service.rs
@@ -143,7 +143,7 @@ mod tests {
 
     #[async_trait]
     impl LanguageServer for Mock {
-        fn initialize(&self, _: &Client, _: InitializeParams) -> Result<InitializeResult> {
+        async fn initialize(&self, _: &Client, _: InitializeParams) -> Result<InitializeResult> {
             Ok(InitializeResult::default())
         }
 


### PR DESCRIPTION
### Changed

* Make `LanguageServer::initialize()` handler asynchronous.
* Update documentation and examples.

Given that we have a mechanism for ensuring that RPC handlers only execute if the server is initialized successfully, there should be no harm in making this function non-blocking as well.

Closes #181.

CC @sawmurai