### PR TITLE
Fix broken client request routing and loosen trait bonuds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,12 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
+//! #   use std::io::Cursor;
 //!     let stdin = tokio::io::stdin();
+//! #   let message = r#"{"jsonrpc":"2.0","method":"exit"}"#;
+//! #   let stdin = Cursor::new(format!("Content-Length: {}\r\n\r\n{}", message.len(), message).into_bytes());
 //!     let stdout = tokio::io::stdout();
+//! #   let stdout = Cursor::new(Vec::new());
 //!
 //!     let (service, messages) = LspService::new(Backend::default());
 //!     Server::new(stdin, stdout)


### PR DESCRIPTION
### Changed

* Remove one internal use of `tokio::spawn()` in favor of `futures::join!()` (see #180).
* Allow `!Send` and `!'static` streams and IO handles to be used with `Server`.
* Update `stdio.rs` tests to take `&mut stdin` and `&mut stdout` and inspect the two buffers afterwards for correctness. This one was a long time coming!

### Fixed

* Fix bidirectional request routing by using `buffer_unordered()`.

It seems that server-to-client request routing (introduced in #134) was broken because of `service.call(request).await` in `Server` blocking forever, preventing the response from being routed back to the awaiting RPC handler. This commit fixes this issue, while also removing some strict trait bounds on the `stdin` and `stdout` handles, as well as the `interleave` stream, and decoupling us a tiny bit further from `tokio`.

Fixes #183.