### PR TITLE
Update to lsp-types requirement to 0.78

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ futures = { version = "0.3", features = ["compat"] }
 jsonrpc-core = "14.0"
 jsonrpc-derive = "14.0"
 log = "0.4"
-lsp-types = ">=0.74, <0.77"
+lsp-types = "0.78"
 nom = { version = "5.1", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -15,7 +15,7 @@ impl LanguageServer for Backend {
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(
                     TextDocumentSyncKind::Incremental,
                 )),
-                hover_provider: Some(true),
+                hover_provider: Some(HoverProviderCapability::Simple(true)),
                 completion_provider: Some(CompletionOptions {
                     resolve_provider: Some(false),
                     trigger_characters: Some(vec![".".to_string()]),


### PR DESCRIPTION
### Changed

* Upgrade to `lsp-types` 0.78 without semver range, since it contains breaking changes to the `ServerCapabilities` struct.
* Update `examples/server.rs` to `lsp-types` 0.78.

Since this update includes missing types for capability un/registration (gluon-lang/lsp-types#170, gluon-lang/lsp-types#171), it should hopefully unblock #190.