### PR TITLE
fix: typo of name didChangeConfiguration

### DIFF
--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -64,7 +64,7 @@ pub trait LanguageServerCore {
     #[rpc(name = "workspace/didChangeWorkspaceFolders", raw_params)]
     fn did_change_workspace_folders(&self, params: Params);
 
-    #[rpc(name = "workspace/DidChangeConfiguration", raw_params)]
+    #[rpc(name = "workspace/didChangeConfiguration", raw_params)]
     fn did_change_configuration(&self, params: Params);
 
     #[rpc(name = "workspace/didChangeWatchedFiles", raw_params)]


### PR DESCRIPTION
The typo causes configuration change not working.