### PR TITLE
Allow language servers to store Client as struct field

### DIFF
--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -3,12 +3,14 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 
-#[derive(Debug, Default)]
-struct Backend;
+#[derive(Debug)]
+struct Backend {
+    client: Client,
+}
 
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
-    async fn initialize(&self, _: &Client, _: InitializeParams) -> Result<InitializeResult> {
+    async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {
             server_info: None,
             capabilities: ServerCapabilities {
@@ -37,60 +39,56 @@ impl LanguageServer for Backend {
         })
     }
 
-    async fn initialized(&self, client: &Client, _: InitializedParams) {
-        client.log_message(MessageType::Info, "server initialized!");
+    async fn initialized(&self, _: InitializedParams) {
+        self.client.log_message(MessageType::Info, "initialized!");
     }
 
     async fn shutdown(&self) -> Result<()> {
         Ok(())
     }
 
-    async fn did_change_workspace_folders(
-        &self,
-        client: &Client,
-        _: DidChangeWorkspaceFoldersParams,
-    ) {
-        client.log_message(MessageType::Info, "workspace folders changed!");
+    async fn did_change_workspace_folders(&self, _: DidChangeWorkspaceFoldersParams) {
+        self.client
+            .log_message(MessageType::Info, "workspace folders changed!");
     }
 
-    async fn did_change_configuration(&self, client: &Client, _: DidChangeConfigurationParams) {
-        client.log_message(MessageType::Info, "configuration changed!");
+    async fn did_change_configuration(&self, _: DidChangeConfigurationParams) {
+        self.client
+            .log_message(MessageType::Info, "configuration changed!");
     }
 
-    async fn did_change_watched_files(&self, client: &Client, _: DidChangeWatchedFilesParams) {
-        client.log_message(MessageType::Info, "watched files have changed!");
+    async fn did_change_watched_files(&self, _: DidChangeWatchedFilesParams) {
+        self.client
+            .log_message(MessageType::Info, "watched files have changed!");
     }
 
-    async fn execute_command(
-        &self,
-        client: &Client,
-        _: ExecuteCommandParams,
-    ) -> Result<Option<Value>> {
-        client.log_message(MessageType::Info, "command executed!");
+    async fn execute_command(&self, _: ExecuteCommandParams) -> Result<Option<Value>> {
+        self.client
+            .log_message(MessageType::Info, "command executed!");
 
-        match client.apply_edit(WorkspaceEdit::default()).await {
-            Ok(res) if res.applied => client.log_message(MessageType::Info, "edit applied"),
-            Ok(_) => client.log_message(MessageType::Info, "edit not applied"),
-            Err(err) => client.log_message(MessageType::Error, err),
+        match self.client.apply_edit(WorkspaceEdit::default()).await {
+            Ok(res) if res.applied => self.client.log_message(MessageType::Info, "edit applied"),
+            Ok(_) => self.client.log_message(MessageType::Info, "edit rejected"),
+            Err(err) => self.client.log_message(MessageType::Error, err),
         }
 
         Ok(None)
     }
 
-    async fn did_open(&self, client: &Client, _: DidOpenTextDocumentParams) {
-        client.log_message(MessageType::Info, "file opened!");
+    async fn did_open(&self, _: DidOpenTextDocumentParams) {
+        self.client.log_message(MessageType::Info, "file opened!");
     }
 
-    async fn did_change(&self, client: &Client, _: DidChangeTextDocumentParams) {
-        client.log_message(MessageType::Info, "file changed!");
+    async fn did_change(&self, _: DidChangeTextDocumentParams) {
+        self.client.log_message(MessageType::Info, "file changed!");
     }
 
-    async fn did_save(&self, client: &Client, _: DidSaveTextDocumentParams) {
-        client.log_message(MessageType::Info, "file saved!");
+    async fn did_save(&self, _: DidSaveTextDocumentParams) {
+        self.client.log_message(MessageType::Info, "file saved!");
     }
 
-    async fn did_close(&self, client: &Client, _: DidCloseTextDocumentParams) {
-        client.log_message(MessageType::Info, "file closed!");
+    async fn did_close(&self, _: DidCloseTextDocumentParams) {
+        self.client.log_message(MessageType::Info, "file closed!");
     }
 
     async fn completion(&self, _: CompletionParams) -> Result<Option<CompletionResponse>> {
@@ -108,7 +106,7 @@ async fn main() {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let (service, messages) = LspService::new(Backend::default());
+    let (service, messages) = LspService::new(|client| Backend { client });
     Server::new(stdin, stdout)
         .interleave(messages)
         .serve(service)

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -4,12 +4,14 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 
-#[derive(Debug, Default)]
-struct Backend;
+#[derive(Debug)]
+struct Backend {
+    client: Client,
+}
 
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
-    async fn initialize(&self, _: &Client, _: InitializeParams) -> Result<InitializeResult> {
+    async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {
             server_info: None,
             capabilities: ServerCapabilities {
@@ -38,60 +40,56 @@ impl LanguageServer for Backend {
         })
     }
 
-    async fn initialized(&self, client: &Client, _: InitializedParams) {
-        client.log_message(MessageType::Info, "server initialized!");
+    async fn initialized(&self, _: InitializedParams) {
+        self.client.log_message(MessageType::Info, "initialized!");
     }
 
     async fn shutdown(&self) -> Result<()> {
         Ok(())
     }
 
-    async fn did_change_workspace_folders(
-        &self,
-        client: &Client,
-        _: DidChangeWorkspaceFoldersParams,
-    ) {
-        client.log_message(MessageType::Info, "workspace folders changed!");
+    async fn did_change_workspace_folders(&self, _: DidChangeWorkspaceFoldersParams) {
+        self.client
+            .log_message(MessageType::Info, "workspace folders changed!");
     }
 
-    async fn did_change_configuration(&self, client: &Client, _: DidChangeConfigurationParams) {
-        client.log_message(MessageType::Info, "configuration changed!");
+    async fn did_change_configuration(&self, _: DidChangeConfigurationParams) {
+        self.client
+            .log_message(MessageType::Info, "configuration changed!");
     }
 
-    async fn did_change_watched_files(&self, client: &Client, _: DidChangeWatchedFilesParams) {
-        client.log_message(MessageType::Info, "watched files have changed!");
+    async fn did_change_watched_files(&self, _: DidChangeWatchedFilesParams) {
+        self.client
+            .log_message(MessageType::Info, "watched files have changed!");
     }
 
-    async fn execute_command(
-        &self,
-        client: &Client,
-        _: ExecuteCommandParams,
-    ) -> Result<Option<Value>> {
-        client.log_message(MessageType::Info, "command executed!");
+    async fn execute_command(&self, _: ExecuteCommandParams) -> Result<Option<Value>> {
+        self.client
+            .log_message(MessageType::Info, "command executed!");
 
-        match client.apply_edit(WorkspaceEdit::default()).await {
-            Ok(res) if res.applied => client.log_message(MessageType::Info, "edit applied"),
-            Ok(_) => client.log_message(MessageType::Info, "edit not applied"),
-            Err(err) => client.log_message(MessageType::Error, err),
+        match self.client.apply_edit(WorkspaceEdit::default()).await {
+            Ok(res) if res.applied => self.client.log_message(MessageType::Info, "edit applied"),
+            Ok(_) => self.client.log_message(MessageType::Info, "edit rejected"),
+            Err(err) => self.client.log_message(MessageType::Error, err),
         }
 
         Ok(None)
     }
 
-    async fn did_open(&self, client: &Client, _: DidOpenTextDocumentParams) {
-        client.log_message(MessageType::Info, "file opened!");
+    async fn did_open(&self, _: DidOpenTextDocumentParams) {
+        self.client.log_message(MessageType::Info, "file opened!");
     }
 
-    async fn did_change(&self, client: &Client, _: DidChangeTextDocumentParams) {
-        client.log_message(MessageType::Info, "file changed!");
+    async fn did_change(&self, _: DidChangeTextDocumentParams) {
+        self.client.log_message(MessageType::Info, "file changed!");
     }
 
-    async fn did_save(&self, client: &Client, _: DidSaveTextDocumentParams) {
-        client.log_message(MessageType::Info, "file saved!");
+    async fn did_save(&self, _: DidSaveTextDocumentParams) {
+        self.client.log_message(MessageType::Info, "file saved!");
     }
 
-    async fn did_close(&self, client: &Client, _: DidCloseTextDocumentParams) {
-        client.log_message(MessageType::Info, "file closed!");
+    async fn did_close(&self, _: DidCloseTextDocumentParams) {
+        self.client.log_message(MessageType::Info, "file closed!");
     }
 
     async fn completion(&self, _: CompletionParams) -> Result<Option<CompletionResponse>> {
@@ -110,7 +108,7 @@ async fn main() {
     let (stream, _) = listener.accept().await.unwrap();
     let (read, write) = tokio::io::split(stream);
 
-    let (service, messages) = LspService::new(Backend::default());
+    let (service, messages) = LspService::new(|client| Backend { client });
     Server::new(read, write)
         .interleave(messages)
         .serve(service)


### PR DESCRIPTION
### Changed

* Change `LspService::new()` to accept an `FnOnce(Client) -> T` closure instead of an already initialized `T` value.
* Remove all `&Client` parameters from all `LanguageServer` trait methods.

These changes should enable users to initialize `LanguageServer` implementers with `tower_lsp::Client` conveniently stored as a struct field instead of having it passed into each callback method as an argument. Initialization would theoretically look like this:

```rust
#[tokio::main]
async fn main() {
    let stdin = tokio::io::stdin();
    let stdout = tokio::io::stdout();

    // let (service, messages) = LspService::new(Backend { ??? }); // Current
    let (service, messages) = LspService::new(|client| Backend { client }); // New
    Server::new(stdin, stdout)
        .interleave(messages)
        .serve(service)
        .await;
}
```

Additional resources required by the language server struct can be initialized ahead of time in `main()` and passed into the closure, if needed.

CC @Timmmm @icsaszar

Closes #189.