### PR TITLE
Fix incorrect reference in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 * Remove dependency on `jsonrpc-core`, as `tower-lsp` no longer relies on it.
-* Remove `Server::with_handler()` constructor (PR #202).
+* Remove `LspService::with_handler()` constructor (PR #202).
 
 ## [0.11.0] - 2020-04-30
 


### PR DESCRIPTION
### Fixed

* Correct `Server` to `LspService` in `CHANGELOG.md` entry for the 0.12.0 release.

Follow-up to #203.