### PR TITLE
Simplify server state machine

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -289,7 +289,7 @@ impl Client {
     where
         R: Request,
     {
-        if self.inner.state.get() == State::Initialized {
+        if let State::Initialized | State::ShutDown = self.inner.state.get() {
             self.send_request::<R>(params).await
         } else {
             let id = self.inner.request_id.load(Ordering::SeqCst) + 1;
@@ -303,7 +303,7 @@ impl Client {
     where
         N: Notification,
     {
-        if self.inner.state.get() == State::Initialized {
+        if let State::Initialized | State::ShutDown = self.inner.state.get() {
             self.send_notification::<N>(params);
         } else {
             let msg = ClientRequest::notification::<N>(params);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,9 @@ pub use self::transport::Server;
 /// A re-export of [`async-trait`](https://docs.rs/async-trait) for convenience.
 pub use async_trait::async_trait;
 
+use std::fmt::{self, Debug, Formatter};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use auto_impl::auto_impl;
 use log::{error, warn};
 use lsp_types::request::{
@@ -766,4 +769,49 @@ pub trait LanguageServer: Send + Sync + 'static {
 fn _assert_object_safe() {
     fn assert_impl<T: LanguageServer>() {}
     assert_impl::<Box<dyn LanguageServer>>();
+}
+
+/// Atomic value which represents the current state of the server.
+struct ServerState(AtomicUsize);
+
+impl ServerState {
+    #[inline]
+    const fn new() -> Self {
+        ServerState(AtomicUsize::new(State::Uninitialized as usize))
+    }
+
+    #[inline]
+    fn set(&self, state: State) {
+        self.0.store(state as usize, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn get(&self) -> State {
+        match self.0.load(Ordering::SeqCst) {
+            0 => State::Uninitialized,
+            1 => State::Initialized,
+            2 => State::ShutDown,
+            3 => State::Exited,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Debug for ServerState {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        self.get().fmt(f)
+    }
+}
+
+/// A list of possible states the language server can be in.
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum State {
+    /// Server has not received an `initialize` request.
+    Uninitialized = 0,
+    /// Server received and responded to an `initialize` request.
+    Initialized = 1,
+    /// Server received a `shutdown` request.
+    ShutDown = 2,
+    /// Server received an `exit` notification.
+    Exited = 3,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -789,9 +789,10 @@ impl ServerState {
     fn get(&self) -> State {
         match self.0.load(Ordering::SeqCst) {
             0 => State::Uninitialized,
-            1 => State::Initialized,
-            2 => State::ShutDown,
-            3 => State::Exited,
+            1 => State::Initializing,
+            2 => State::Initialized,
+            3 => State::ShutDown,
+            4 => State::Exited,
             _ => unreachable!(),
         }
     }
@@ -808,10 +809,12 @@ impl Debug for ServerState {
 enum State {
     /// Server has not received an `initialize` request.
     Uninitialized = 0,
-    /// Server received and responded to an `initialize` request.
-    Initialized = 1,
+    /// Server received an `initialize` request, but has not yet responded.
+    Initializing = 1,
+    /// Server received and responded success to an `initialize` request.
+    Initialized = 2,
     /// Server received a `shutdown` request.
-    ShutDown = 2,
+    ShutDown = 3,
     /// Server received an `exit` notification.
-    Exited = 3,
+    Exited = 4,
 }


### PR DESCRIPTION
### Changed

* Simplify state machine by replacing the standalone `AtomicBool`s with a single `ServerState` value.

### Fixed

* Reject multiple `initialize` requests sent in very quick succession before the server has time to respond. This is unlikely to happen since it's against the LSP spec and the client would have to be hopelessly buggy, but we should cover this case nonetheless.