### PR TITLE
Prepare release 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.12.1] - 2020-08-11]
+
+### Fixed
+
+* Reject multiple `initialize` requests sent in quick succession (PR #208).
+* Fix bug deserializing `jsonrpc` field from `serde_json::Value` (PR #209).
+
 ## [0.12.0] - 2020-08-09]
 
 ### Added
@@ -326,7 +333,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * `textDocument/hover`
   * `textDocument/documentHighlight`
 
-[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.10.0...v0.10.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 edition = "2018"
 description = "Language Server Protocol implementation based on Tower"
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "0.2", features = ["rt-core"] }
 tokio-util = { version = "0.3", features = ["codec"] }
-tower-lsp-macros = { version = "0.1", path = "./tower-lsp-macros" }
+tower-lsp-macros = { version = "0.2", path = "./tower-lsp-macros" }
 tower-service = "0.3"
 
 [dev-dependencies]

--- a/tower-lsp-macros/Cargo.toml
+++ b/tower-lsp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp-macros"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Internal procedural macros for tower-lsp"
 edition = "2018"


### PR DESCRIPTION
### Changed

* Update `CHANGELOG.md`.
* Bump crate version to 0.12.1.