### PR TITLE
Improve error message of missing or invalid params 

### DIFF
--- a/src/jsonrpc/error.rs
+++ b/src/jsonrpc/error.rs
@@ -154,13 +154,7 @@ impl Error {
 
     /// Creates a new "invalid params" error (`-32602`).
     #[inline]
-    pub fn invalid_params() -> Self {
-        Error::new(ErrorCode::InvalidParams)
-    }
-
-    /// Creates a new "invalid params" error (`-32602`) with the given message.
-    #[inline]
-    pub fn invalid_params_message<M>(message: M) -> Self
+    pub fn invalid_params<M>(message: M) -> Self
     where
         M: Into<String>,
     {

--- a/src/service.rs
+++ b/src/service.rs
@@ -132,16 +132,12 @@ impl Service<Incoming> for LspService {
                 }
                 Incoming::Invalid { id, method } => match (id, method) {
                     (None, Some(method)) if method.starts_with("$/") => future::ok(None).boxed(),
-                    (Some(id), Some(method)) => {
-                        error!("received invalid JSON message {:?} with ID: {}", method, id);
-                        let res = Response::error(Some(id), jsonrpc::Error::method_not_found());
+                    (id, Some(method)) => {
+                        error!("method {:?} not found", method);
+                        let res = Response::error(id, jsonrpc::Error::method_not_found());
                         future::ok(Some(Outgoing::Response(res))).boxed()
                     }
-                    (id, _) => {
-                        match &id {
-                            Some(id) => error!("received invalid JSON message with ID: {}", id),
-                            None => error!("received invalid JSON message"),
-                        }
+                    (id, None) => {
                         let res = Response::error(id, jsonrpc::Error::invalid_request());
                         future::ok(Some(Outgoing::Response(res))).boxed()
                     }


### PR DESCRIPTION
### Changed

* Improve log message quality and reduce noise.

### Fixed

* Report missing `params` field (for messages that require it) as "invalid params" instead of "parse error."