### PR TITLE
Return responses in corresponding request order

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -91,11 +91,11 @@ where
         T::Error: Into<Box<dyn Error + Send + Sync>>,
         T::Future: Send,
     {
-        let (mut sender, receiver) = mpsc::channel(1);
+        let (mut sender, receiver) = mpsc::channel(16);
 
         let framed_stdin = FramedRead::new(self.stdin, LanguageServerCodec::default());
         let framed_stdout = FramedWrite::new(self.stdout, LanguageServerCodec::default());
-        let responses = receiver.buffer_unordered(4).filter_map(future::ready);
+        let responses = receiver.buffered(4).filter_map(future::ready);
         let interleave = self.interleave.fuse();
 
         let mut messages = framed_stdin


### PR DESCRIPTION
### Changed

* Return responses in corresponding request order, following the advice of https://github.com/microsoft/language-server-protocol/issues/306.

While the server implementation is free to process incoming requests concurrently in whatever order it wants, it is generally preferred for servers to send responses back to the client in the same order the requests were sent, for the sake of convenience on the client side.

To ensure we don't stall the executor in cases of exceptionally high bidirectional traffic, we also increase the minimum buffer size for processing `stdin` messages from 1 to 16. In practice, typing extremely quickly in my own editor, this seemed to be a pretty reasonable threshold.