### PR TITLE
Change all Client methods to async fn

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust-version: [1.40.0, beta, nightly]
+        rust-version: [1.41.0, beta, nightly]
         include:
         - rust-version: nightly
           continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ impl LanguageServer for Backend {
     }
 
     async fn initialized(&self, _: InitializedParams) {
-        self.client.log_message(MessageType::Info, "server initialized!");
+        self.client
+            .log_message(MessageType::Info, "server initialized!")
+            .await;
     }
 
     async fn shutdown(&self) -> Result<()> {

--- a/examples/custom_notification.rs
+++ b/examples/custom_notification.rs
@@ -20,11 +20,11 @@ impl CustomNotificationParams {
     }
 }
 
-#[derive(Debug)]
 enum CustomNotification {}
 
 impl Notification for CustomNotification {
     type Params = CustomNotificationParams;
+
     const METHOD: &'static str = "custom/notification";
 }
 
@@ -54,13 +54,17 @@ impl LanguageServer for Backend {
 
     async fn execute_command(&self, params: ExecuteCommandParams) -> Result<Option<Value>> {
         if params.command == "custom.notification" {
-            self.client.send_custom_notification::<CustomNotification>(
-                CustomNotificationParams::new("Hello", "Message"),
-            );
-            self.client.log_message(
-                MessageType::Info,
-                format!("Command executed with params: {:?}", params),
-            );
+            self.client
+                .send_custom_notification::<CustomNotification>(CustomNotificationParams::new(
+                    "Hello", "Message",
+                ))
+                .await;
+            self.client
+                .log_message(
+                    MessageType::Info,
+                    format!("Command executed with params: {:?}", params),
+                )
+                .await;
             Ok(None)
         } else {
             Err(Error::invalid_request())

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -40,7 +40,9 @@ impl LanguageServer for Backend {
     }
 
     async fn initialized(&self, _: InitializedParams) {
-        self.client.log_message(MessageType::Info, "initialized!");
+        self.client
+            .log_message(MessageType::Info, "initialized!")
+            .await;
     }
 
     async fn shutdown(&self) -> Result<()> {
@@ -49,46 +51,58 @@ impl LanguageServer for Backend {
 
     async fn did_change_workspace_folders(&self, _: DidChangeWorkspaceFoldersParams) {
         self.client
-            .log_message(MessageType::Info, "workspace folders changed!");
+            .log_message(MessageType::Info, "workspace folders changed!")
+            .await;
     }
 
     async fn did_change_configuration(&self, _: DidChangeConfigurationParams) {
         self.client
-            .log_message(MessageType::Info, "configuration changed!");
+            .log_message(MessageType::Info, "configuration changed!")
+            .await;
     }
 
     async fn did_change_watched_files(&self, _: DidChangeWatchedFilesParams) {
         self.client
-            .log_message(MessageType::Info, "watched files have changed!");
+            .log_message(MessageType::Info, "watched files have changed!")
+            .await;
     }
 
     async fn execute_command(&self, _: ExecuteCommandParams) -> Result<Option<Value>> {
         self.client
-            .log_message(MessageType::Info, "command executed!");
+            .log_message(MessageType::Info, "command executed!")
+            .await;
 
         match self.client.apply_edit(WorkspaceEdit::default()).await {
-            Ok(res) if res.applied => self.client.log_message(MessageType::Info, "edit applied"),
-            Ok(_) => self.client.log_message(MessageType::Info, "edit rejected"),
-            Err(err) => self.client.log_message(MessageType::Error, err),
+            Ok(res) if res.applied => self.client.log_message(MessageType::Info, "applied").await,
+            Ok(_) => self.client.log_message(MessageType::Info, "rejected").await,
+            Err(err) => self.client.log_message(MessageType::Error, err).await,
         }
 
         Ok(None)
     }
 
     async fn did_open(&self, _: DidOpenTextDocumentParams) {
-        self.client.log_message(MessageType::Info, "file opened!");
+        self.client
+            .log_message(MessageType::Info, "file opened!")
+            .await;
     }
 
     async fn did_change(&self, _: DidChangeTextDocumentParams) {
-        self.client.log_message(MessageType::Info, "file changed!");
+        self.client
+            .log_message(MessageType::Info, "file changed!")
+            .await;
     }
 
     async fn did_save(&self, _: DidSaveTextDocumentParams) {
-        self.client.log_message(MessageType::Info, "file saved!");
+        self.client
+            .log_message(MessageType::Info, "file saved!")
+            .await;
     }
 
     async fn did_close(&self, _: DidCloseTextDocumentParams) {
-        self.client.log_message(MessageType::Info, "file closed!");
+        self.client
+            .log_message(MessageType::Info, "file closed!")
+            .await;
     }
 
     async fn completion(&self, _: CompletionParams) -> Result<Option<CompletionResponse>> {

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -41,7 +41,9 @@ impl LanguageServer for Backend {
     }
 
     async fn initialized(&self, _: InitializedParams) {
-        self.client.log_message(MessageType::Info, "initialized!");
+        self.client
+            .log_message(MessageType::Info, "initialized!")
+            .await;
     }
 
     async fn shutdown(&self) -> Result<()> {
@@ -50,46 +52,58 @@ impl LanguageServer for Backend {
 
     async fn did_change_workspace_folders(&self, _: DidChangeWorkspaceFoldersParams) {
         self.client
-            .log_message(MessageType::Info, "workspace folders changed!");
+            .log_message(MessageType::Info, "workspace folders changed!")
+            .await;
     }
 
     async fn did_change_configuration(&self, _: DidChangeConfigurationParams) {
         self.client
-            .log_message(MessageType::Info, "configuration changed!");
+            .log_message(MessageType::Info, "configuration changed!")
+            .await;
     }
 
     async fn did_change_watched_files(&self, _: DidChangeWatchedFilesParams) {
         self.client
-            .log_message(MessageType::Info, "watched files have changed!");
+            .log_message(MessageType::Info, "watched files have changed!")
+            .await;
     }
 
     async fn execute_command(&self, _: ExecuteCommandParams) -> Result<Option<Value>> {
         self.client
-            .log_message(MessageType::Info, "command executed!");
+            .log_message(MessageType::Info, "command executed!")
+            .await;
 
         match self.client.apply_edit(WorkspaceEdit::default()).await {
-            Ok(res) if res.applied => self.client.log_message(MessageType::Info, "edit applied"),
-            Ok(_) => self.client.log_message(MessageType::Info, "edit rejected"),
-            Err(err) => self.client.log_message(MessageType::Error, err),
+            Ok(res) if res.applied => self.client.log_message(MessageType::Info, "applied").await,
+            Ok(_) => self.client.log_message(MessageType::Info, "rejected").await,
+            Err(err) => self.client.log_message(MessageType::Error, err).await,
         }
 
         Ok(None)
     }
 
     async fn did_open(&self, _: DidOpenTextDocumentParams) {
-        self.client.log_message(MessageType::Info, "file opened!");
+        self.client
+            .log_message(MessageType::Info, "file opened!")
+            .await;
     }
 
     async fn did_change(&self, _: DidChangeTextDocumentParams) {
-        self.client.log_message(MessageType::Info, "file changed!");
+        self.client
+            .log_message(MessageType::Info, "file changed!")
+            .await;
     }
 
     async fn did_save(&self, _: DidSaveTextDocumentParams) {
-        self.client.log_message(MessageType::Info, "file saved!");
+        self.client
+            .log_message(MessageType::Info, "file saved!")
+            .await;
     }
 
     async fn did_close(&self, _: DidCloseTextDocumentParams) {
-        self.client.log_message(MessageType::Info, "file closed!");
+        self.client
+            .log_message(MessageType::Info, "file closed!")
+            .await;
     }
 
     async fn completion(&self, _: CompletionParams) -> Result<Option<CompletionResponse>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,9 @@
 //!     }
 //!
 //!     async fn initialized(&self, _: InitializedParams) {
-//!         self.client.log_message(MessageType::Info, "server initialized!");
+//!         self.client
+//!             .log_message(MessageType::Info, "server initialized!")
+//!             .await;
 //!     }
 //!
 //!     async fn shutdown(&self) -> Result<()> {


### PR DESCRIPTION
### Changed

* Change remaining `Client` notification methods to `async fn`.
* Update minimum supported Rust version to 1.41.0.

With this PR, we have eliminated all uses of `tokio::spawn` in `tower-lsp`! 🎉 The only things currently tying us to `tokio` at the moment are the `AsyncRead` and `AsyncWrite` traits. The Rust ecosystem is currently split down the middle between the `tokio` and `futures`/`async-std` versions of these traits, unfortunately, although efforts exist to [stabilize them in `std`](https://github.com/rust-lang/futures-rs/issues/2105).

Closes #180.