### PR TITLE
Prepare release 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.13.2] - 2020-09-03
+
+### Changed
+
+* Increase `lsp-types` semantic version range to `>=0.79,<0.81`. This is safe
+  because the changes only concern proposed LSP changes, which this library does
+  not currently support.
+
 ## [0.13.1] - 2020-08-21
 
 ### Changed
@@ -359,7 +367,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * `textDocument/hover`
   * `textDocument/documentHighlight`
 
-[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.13.2...HEAD
+[0.13.2]: https://github.com/ebkalderon/tower-lsp/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.12.0...v0.12.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 edition = "2018"
 description = "Language Server Protocol implementation based on Tower"


### PR DESCRIPTION
### Changed

* Update `CHANGELOG.md`.
* Bump crate version to 0.13.2.