### PR TITLE
Upgrade to lsp-types 0.82

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bytes = "0.5"
 dashmap = "3.5.1"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 log = "0.4"
-lsp-types = ">=0.79, <0.82"
+lsp-types = "0.82"
 nom = { version = "5.1", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
### Changed

* Replace semantic version range for `lsp-types` with `^0.82` due to breaking changes.

As mentioned in https://github.com/ebkalderon/tower-lsp/pull/224#issuecomment-698291689, since this version includes breaking changes to the public interface (the `ServerCapabilities` struct, in this case), we cannot safely maintain a semver range any longer and must upgrade to the latest minor version.

Supersedes #224.