### PR TITLE
Permit window/showMessageRequest while uninitialized

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -84,20 +84,13 @@ impl Client {
     /// This corresponds to the [`window/showMessageRequest`] request.
     ///
     /// [`window/showMessageRequest`]: https://microsoft.github.io/language-server-protocol/specification#window_showMessageRequest
-    ///
-    /// # Initialization
-    ///
-    /// If the request is sent to client before the server has been initialized, this will
-    /// immediately return `Err` with JSON-RPC error code `-32002` ([read more]).
-    ///
-    /// [read more]: https://microsoft.github.io/language-server-protocol/specification#initialize
     pub async fn show_message_request<M: Display>(
         &self,
         typ: MessageType,
         message: M,
         actions: Option<Vec<MessageActionItem>>,
     ) -> Result<Option<MessageActionItem>> {
-        self.send_request_initialized::<ShowMessageRequest>(ShowMessageRequestParams {
+        self.send_request::<ShowMessageRequest>(ShowMessageRequestParams {
             typ,
             message: message.to_string(),
             actions,


### PR DESCRIPTION
### Fixed

* Allow `Client::show_message_request()` requests to be sent while the server is uninitialized or initializing.

According to the [LSP specification], the following client requests are allowed to be sent to the client while uninitialized:

* `window/logMessage`
* `window/showMessage`
* `window/showMessageRequest`
* `telemetry/event`

The current code suppresses attempts to send `window/showMessageRequest` requests to the language client if the server has not yet been initialized, which is clearly wrong, as explained above.

[LSP specification]: https://microsoft.github.io/language-server-protocol/specification#initialize