### PR TITLE
chore: update dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust-version: [1.43.0, beta, nightly]
+        rust-version: [1.44.0, beta, nightly]
         include:
         - rust-version: nightly
           continue-on-error: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust-version: [1.41.0, beta, nightly]
+        rust-version: [1.43.0, beta, nightly]
         include:
         - rust-version: nightly
           continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-* Bump minimum supported Rust version to 1.43.0 (PR #238).
+* Bump minimum supported Rust version to 1.44.0 (PR #243).
+* Update `lsp-types` crate from `>=0.79, <0.82` to `0.85` (PR #243).
+* Update `tokio` crate from `0.2` to `0.3` (PR #243).
 
 ## [0.13.3] - 2020-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+* Bump minimum supported Rust version to 1.43.0 (PR #238).
+
 ## [0.13.3] - 2020-09-19
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,22 +16,22 @@ exclude = ["./tower-lsp-macros"]
 [dependencies]
 async-trait = "0.1"
 auto_impl = "0.4"
-bytes = "0.5"
+bytes = "0.6"
 dashmap = "3.5.1"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 log = "0.4"
-lsp-types = "0.82"
+lsp-types = "0.83"
 nom = { version = "5.1", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "0.2", features = ["rt-core"] }
-tokio-util = { version = "0.3", features = ["codec"] }
+tokio = { version = "0.3", features = ["rt", "rt-multi-thread", "time"] }
+tokio-util = { version = "0.5", features = ["codec"] }
 tower-lsp-macros = { version = "0.3", path = "./tower-lsp-macros" }
 tower-service = "0.3"
 
 [dev-dependencies]
-env_logger = "0.7"
-tokio = { version = "0.2", features = ["io-std", "io-util", "macros", "net", "test-util"] }
+env_logger = "0.8"
+tokio = { version = "0.3", features = ["io-std", "io-util", "macros", "net", "test-util"] }
 tower-test = "0.3"
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ exclude = ["./tower-lsp-macros"]
 async-trait = "0.1"
 auto_impl = "0.4"
 bytes = "0.6"
-dashmap = "3.5.1"
+dashmap = "3.11.10"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 log = "0.4"
-lsp-types = "0.83"
+lsp-types = "0.85.0"
 nom = { version = "5.1", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -72,7 +72,7 @@ impl LanguageServer for Backend {
             .log_message(MessageType::Info, "command executed!")
             .await;
 
-        match self.client.apply_edit(WorkspaceEdit::default()).await {
+        match self.client.apply_edit(WorkspaceEdit::default(), None).await {
             Ok(res) if res.applied => self.client.log_message(MessageType::Info, "applied").await,
             Ok(_) => self.client.log_message(MessageType::Info, "rejected").await,
             Err(err) => self.client.log_message(MessageType::Error, err).await,

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -118,7 +118,7 @@ impl LanguageServer for Backend {
 async fn main() {
     env_logger::init();
 
-    let mut listener = TcpListener::bind("127.0.0.1:9257").await.unwrap();
+    let listener = TcpListener::bind("127.0.0.1:9257").await.unwrap();
     let (stream, _) = listener.accept().await.unwrap();
     let (read, write) = tokio::io::split(stream);
 

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -73,7 +73,7 @@ impl LanguageServer for Backend {
             .log_message(MessageType::Info, "command executed!")
             .await;
 
-        match self.client.apply_edit(WorkspaceEdit::default()).await {
+        match self.client.apply_edit(WorkspaceEdit::default(), None).await {
             Ok(res) if res.applied => self.client.log_message(MessageType::Info, "applied").await,
             Ok(_) => self.client.log_message(MessageType::Info, "rejected").await,
             Err(err) => self.client.log_message(MessageType::Error, err).await,

--- a/src/client.rs
+++ b/src/client.rs
@@ -216,9 +216,16 @@ impl Client {
     /// immediately return `Err` with JSON-RPC error code `-32002` ([read more]).
     ///
     /// [read more]: https://microsoft.github.io/language-server-protocol/specification#initialize
-    pub async fn apply_edit(&self, edit: WorkspaceEdit) -> Result<ApplyWorkspaceEditResponse> {
-        self.send_request_initialized::<ApplyWorkspaceEdit>(ApplyWorkspaceEditParams { edit })
-            .await
+    pub async fn apply_edit(
+        &self,
+        edit: WorkspaceEdit,
+        label: Option<String>,
+    ) -> Result<ApplyWorkspaceEditResponse> {
+        self.send_request_initialized::<ApplyWorkspaceEdit>(ApplyWorkspaceEditParams {
+            edit,
+            label,
+        })
+        .await
     }
 
     /// Submits validation diagnostics for an open file with the given URI.
@@ -234,7 +241,7 @@ impl Client {
         &self,
         uri: Url,
         diags: Vec<Diagnostic>,
-        version: Option<i64>,
+        version: Option<i32>,
     ) {
         self.send_notification_initialized::<PublishDiagnostics>(PublishDiagnosticsParams::new(
             uri, diags, version,

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -6,8 +6,7 @@ use std::io::{Error as IoError, Write};
 use std::marker::PhantomData;
 use std::str::{self, Utf8Error};
 
-use bytes::buf::ext::BufMutExt;
-use bytes::{Buf, BytesMut};
+use bytes::{Buf, BufMut, BytesMut};
 use log::trace;
 use nom::branch::alt;
 use nom::bytes::streaming::{is_not, tag};

--- a/src/jsonrpc/pending.rs
+++ b/src/jsonrpc/pending.rs
@@ -162,11 +162,11 @@ mod tests {
 
         let id = Id::Number(1);
         let handler_fut = tokio::spawn(pending.execute(id.clone(), async {
-            tokio::time::delay_for(Duration::from_secs(50)).await;
+            tokio::time::sleep(Duration::from_secs(50)).await;
             Ok(json!({}))
         }));
 
-        tokio::time::delay_for(Duration::from_millis(30)).await;
+        tokio::time::sleep(Duration::from_millis(30)).await;
         pending.cancel(&id);
 
         let res = handler_fut.await.expect("task panicked");


### PR DESCRIPTION
This PR builds on #238, but additionally updates `lsp-types` and `dashmap`.

cc @ebkalderon
