### PR TITLE
Update Tokio dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust-version: [1.41.0, beta, nightly]
+        rust-version: [stable, beta, nightly]
         include:
         - rust-version: nightly
           continue-on-error: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["./tower-lsp-macros"]
 [dependencies]
 async-trait = "0.1"
 auto_impl = "0.4"
-bytes = "0.5"
+bytes = "1.0"
 dashmap = "3.5.1"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 log = "0.4"
@@ -24,15 +24,15 @@ lsp-types = "0.82"
 nom = { version = "5.1", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "0.2", features = ["rt-core"] }
-tokio-util = { version = "0.3", features = ["codec"] }
+tokio = { version = "1", features = ["rt"] }
+tokio-util = { version = "0.6", features = ["codec"] }
 tower-lsp-macros = { version = "0.3", path = "./tower-lsp-macros" }
 tower-service = "0.3"
 
 [dev-dependencies]
 env_logger = "0.7"
-tokio = { version = "0.2", features = ["io-std", "io-util", "macros", "net", "test-util"] }
-tower-test = "0.3"
+tokio = { version = "1", features = ["rt-multi-thread", "io-std", "io-util", "macros", "net", "test-util", "time"] }
+tower-test = "0.4"
 
 [workspace]
 members = [".", "./tower-lsp-macros"]

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -6,8 +6,7 @@ use std::io::{Error as IoError, Write};
 use std::marker::PhantomData;
 use std::str::{self, Utf8Error};
 
-use bytes::buf::ext::BufMutExt;
-use bytes::{Buf, BytesMut};
+use bytes::{Buf, BufMut, BytesMut};
 use log::trace;
 use nom::branch::alt;
 use nom::bytes::streaming::{is_not, tag};

--- a/src/jsonrpc/pending.rs
+++ b/src/jsonrpc/pending.rs
@@ -162,11 +162,11 @@ mod tests {
 
         let id = Id::Number(1);
         let handler_fut = tokio::spawn(pending.execute(id.clone(), async {
-            tokio::time::delay_for(Duration::from_secs(50)).await;
+            tokio::time::sleep(Duration::from_secs(50)).await;
             Ok(json!({}))
         }));
 
-        tokio::time::delay_for(Duration::from_millis(30)).await;
+        tokio::time::sleep(Duration::from_millis(30)).await;
         pending.cancel(&id);
 
         let res = handler_fut.await.expect("task panicked");


### PR DESCRIPTION
This PR updates Tokio to 1.x, and includes a few other related and necessary dependency updates.
There are only two small code changes required after updating Tokyo, both related to renamed APIs.

The code builds fine, tests pass and the LSP server in the examples starts up fine.