### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust-version: [1.41.0, beta, nightly]
+        rust-version: [1.45.0, beta, nightly]
         include:
         - rust-version: nightly
           continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Bump minimum supported Rust version from `1.41.0` to `1.45.0` (PR #264).
 * Update `lsp-types` from `0.82` to `0.89` (PR #264)
-* Update `tokio` from `0.2` to `1.4.0` (PR #264)
+* Update `tokio` from `0.2` to `1.6.0` (PR #264, PR #268)
 * Update `tokio-util` from `0.3` to `0.6.5` (PR #264)
 * Update `bytes` from `0.5` to `1.0.1` (PR #264)
 * Update `dashmap` from `3.5.1` to `4.0.2` (PR #264)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-* Update `lsp-types` from `0.82` to `0.89`
-* Update `tokio` from `0.2` to `1.4.0`
-* Update `tokio-util` from `0.3` to `0.6.5`
-* Update `bytes` from `0.5` to `1.0.1`
-* Update `dashmap` from `3.5.1` to `4.0.2`
-* Update `nom` from `5.1` to `6.1.2`
-* Update `env_logger` from `0.7` to `0.8.3` (dev-dependencies)
-* Update `tower-test` from `0.3` to `0.4` (dev-dependencies)
+* Bump minimum supported Rust version from `1.41.0` to `1.45.0` (PR #264).
+* Update `lsp-types` from `0.82` to `0.89` (PR #264)
+* Update `tokio` from `0.2` to `1.4.0` (PR #264)
+* Update `tokio-util` from `0.3` to `0.6.5` (PR #264)
+* Update `bytes` from `0.5` to `1.0.1` (PR #264)
+* Update `dashmap` from `3.5.1` to `4.0.2` (PR #264)
+* Update `nom` from `5.1` to `6.1.2` (PR #264)
+* Update `env_logger` from `0.7` to `0.8.3` (dev-dependencies) (PR #264)
+* Update `tower-test` from `0.3` to `0.4` (dev-dependencies) (PR #264)
 
 ## [0.13.3] - 2020-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+* Update `lsp-types` from `0.82` to `0.89`
+* Update `tokio` from `0.2` to `1.4.0`
+* Update `bytes` from `0.5` to `1.0.1`
+* Update `dashmap` from `3.5.1` to `4.0.2`
+* Update `nom` from `5.1` to `6.1.2`
+* Update `env_logger` from `0.7` to `0.8.3` (dev-dependencies)
+* Update `tower-test` from `0.3` to `0.4` (dev-dependencies)
+
 ## [0.13.3] - 2020-09-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Update `lsp-types` from `0.82` to `0.89`
 * Update `tokio` from `0.2` to `1.4.0`
+* Update `tokio-util` from `0.3` to `0.6.5`
 * Update `bytes` from `0.5` to `1.0.1`
 * Update `dashmap` from `3.5.1` to `4.0.2`
 * Update `nom` from `5.1` to `6.1.2`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ dashmap = "4.0.2"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 log = "0.4"
 lsp-types = "0.89.0"
-nom = { version = "5.1", default-features = false, features = ["std"] }
+nom = { version = "6.1.2", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.4.0", features = ["rt-multi-thread", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ exclude = ["./tower-lsp-macros"]
 async-trait = "0.1"
 auto_impl = "0.4"
 bytes = "1.0.1"
-dashmap = "3.5.1"
+dashmap = "4.0.2"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 log = "0.4"
-lsp-types = "0.82"
+lsp-types = "0.89.0"
 nom = { version = "5.1", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["./tower-lsp-macros"]
 [dependencies]
 async-trait = "0.1"
 auto_impl = "0.4"
-bytes = "0.5"
+bytes = "1.0.1"
 dashmap = "3.5.1"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 log = "0.4"
@@ -24,14 +24,14 @@ lsp-types = "0.82"
 nom = { version = "5.1", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "0.2", features = ["rt-core"] }
-tokio-util = { version = "0.3", features = ["codec"] }
+tokio = { version = "1.4.0", features = ["rt-multi-thread", "time"] }
+tokio-util = { version = "0.6.5", features = ["codec"] }
 tower-lsp-macros = { version = "0.3", path = "./tower-lsp-macros" }
 tower-service = "0.3"
 
 [dev-dependencies]
 env_logger = "0.7"
-tokio = { version = "0.2", features = ["io-std", "io-util", "macros", "net", "test-util"] }
+tokio = { version = "1.4.0", features = ["io-std", "io-util", "macros", "net", "test-util"] }
 tower-test = "0.3"
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ lsp-types = "0.89.0"
 nom = { version = "6.1.2", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.4.0", features = ["rt-multi-thread", "time"] }
+tokio = { version = "1.6.0", features = ["rt-multi-thread", "time"] }
 tokio-util = { version = "0.6.5", features = ["codec"] }
 tower-lsp-macros = { version = "0.3", path = "./tower-lsp-macros" }
 tower-service = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ tower-lsp-macros = { version = "0.3", path = "./tower-lsp-macros" }
 tower-service = "0.3"
 
 [dev-dependencies]
-env_logger = "0.7"
+env_logger = "0.8.3"
 tokio = { version = "1.4.0", features = ["io-std", "io-util", "macros", "net", "test-util"] }
-tower-test = "0.3"
+tower-test = "0.4"
 
 [workspace]
 members = [".", "./tower-lsp-macros"]

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -21,18 +21,18 @@ impl LanguageServer for Backend {
                     resolve_provider: Some(false),
                     trigger_characters: Some(vec![".".to_string()]),
                     work_done_progress_options: Default::default(),
+                    all_commit_characters: None,
                 }),
                 execute_command_provider: Some(ExecuteCommandOptions {
                     commands: vec!["dummy.do_something".to_string()],
                     work_done_progress_options: Default::default(),
                 }),
-                workspace: Some(WorkspaceCapability {
-                    workspace_folders: Some(WorkspaceFolderCapability {
+                workspace: Some(WorkspaceServerCapabilities {
+                    workspace_folders: Some(WorkspaceFoldersServerCapabilities {
                         supported: Some(true),
-                        change_notifications: Some(
-                            WorkspaceFolderCapabilityChangeNotifications::Bool(true),
-                        ),
+                        change_notifications: Some(OneOf::Left(true)),
                     }),
+                    file_operations: None,
                 }),
                 ..ServerCapabilities::default()
             },

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -118,7 +118,7 @@ impl LanguageServer for Backend {
 async fn main() {
     env_logger::init();
 
-    let mut listener = TcpListener::bind("127.0.0.1:9257").await.unwrap();
+    let listener = TcpListener::bind("127.0.0.1:9257").await.unwrap();
     let (stream, _) = listener.accept().await.unwrap();
     let (read, write) = tokio::io::split(stream);
 

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -22,18 +22,18 @@ impl LanguageServer for Backend {
                     resolve_provider: Some(false),
                     trigger_characters: Some(vec![".".to_string()]),
                     work_done_progress_options: Default::default(),
+                    all_commit_characters: None,
                 }),
                 execute_command_provider: Some(ExecuteCommandOptions {
                     commands: vec!["dummy.do_something".to_string()],
                     work_done_progress_options: Default::default(),
                 }),
-                workspace: Some(WorkspaceCapability {
-                    workspace_folders: Some(WorkspaceFolderCapability {
+                workspace: Some(WorkspaceServerCapabilities {
+                    workspace_folders: Some(WorkspaceFoldersServerCapabilities {
                         supported: Some(true),
-                        change_notifications: Some(
-                            WorkspaceFolderCapabilityChangeNotifications::Bool(true),
-                        ),
+                        change_notifications: Some(OneOf::Left(true)),
                     }),
+                    file_operations: None,
                 }),
                 ..ServerCapabilities::default()
             },

--- a/src/client.rs
+++ b/src/client.rs
@@ -217,8 +217,11 @@ impl Client {
     ///
     /// [read more]: https://microsoft.github.io/language-server-protocol/specification#initialize
     pub async fn apply_edit(&self, edit: WorkspaceEdit) -> Result<ApplyWorkspaceEditResponse> {
-        self.send_request_initialized::<ApplyWorkspaceEdit>(ApplyWorkspaceEditParams { edit })
-            .await
+        self.send_request_initialized::<ApplyWorkspaceEdit>(ApplyWorkspaceEditParams {
+            edit,
+            label: None,
+        })
+        .await
     }
 
     /// Submits validation diagnostics for an open file with the given URI.
@@ -234,7 +237,7 @@ impl Client {
         &self,
         uri: Url,
         diags: Vec<Diagnostic>,
-        version: Option<i64>,
+        version: Option<i32>,
     ) {
         self.send_notification_initialized::<PublishDiagnostics>(PublishDiagnosticsParams::new(
             uri, diags, version,

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -6,7 +6,7 @@ use std::io::{Error as IoError, Write};
 use std::marker::PhantomData;
 use std::str::{self, Utf8Error};
 
-use bytes::buf::ext::BufMutExt;
+use bytes::buf::BufMut;
 use bytes::{Buf, BytesMut};
 use log::trace;
 use nom::branch::alt;

--- a/src/jsonrpc/pending.rs
+++ b/src/jsonrpc/pending.rs
@@ -162,11 +162,11 @@ mod tests {
 
         let id = Id::Number(1);
         let handler_fut = tokio::spawn(pending.execute(id.clone(), async {
-            tokio::time::delay_for(Duration::from_secs(50)).await;
+            tokio::time::sleep(Duration::from_secs(50)).await;
             Ok(json!({}))
         }));
 
-        tokio::time::delay_for(Duration::from_millis(30)).await;
+        tokio::time::sleep(Duration::from_millis(30)).await;
         pending.cancel(&id);
 
         let res = handler_fut.await.expect("task panicked");

--- a/tower-lsp-macros/src/lib.rs
+++ b/tower-lsp-macros/src/lib.rs
@@ -45,7 +45,7 @@ struct MethodCall<'a> {
     result: Option<&'a syn::Type>,
 }
 
-fn parse_method_calls<'a>(lang_server_trait: &'a ItemTrait) -> Vec<MethodCall<'a>> {
+fn parse_method_calls(lang_server_trait: &ItemTrait) -> Vec<MethodCall> {
     let mut calls = Vec::new();
 
     for item in &lang_server_trait.items {


### PR DESCRIPTION
## Info
This PR changes:
* Bump minimum supported Rust version from `1.41.0` to `1.45.0`
* Update `lsp-types` from `0.82` to `0.89`
* Update `tokio` from `0.2` to `1.4.0`
* Update `tokio-util` from `0.3` to `0.6.5`
* Update `bytes` from `0.5` to `1.0.1`
* Update `dashmap` from `3.5.1` to `4.0.2`
* Update `nom` from `5.1` to `6.1.2`
* Update `env_logger` from `0.7` to `0.8.3` (dev-dependencies)
* Update `tower-test` from `0.3` to `0.4` (dev-dependencies)
This PR does not add any new features.

Because of changes in dependencies this version needs to be a minor version update, so `0.14.0`.
These changes where tested (and succeeded) on:
* `cargo test --all` (1.51.0, 2021-03-23)
* `cargo +nightly test --all` (1.53.0, 2021-03-24 )
* `cargo build` (1.51.0, 2021-03-23)
* `cargo +nightly build` (1.53.0, 2021-03-24 )
* tested examples
* tested on my project using VSCode

This PR has effect on other PR's and issues:
* Closes: #263, #262, #254, #253, #252, #250, #249, #234
* Effects: #257, #243

### Extra info
Clippy warning was not fixed so only version updates and necessary changes are in PR.
```
warning: explicit lifetimes given in parameter types where they could be elided (or replaced with `'_` if needed by type declaration)
  --> tower-lsp-macros/src/lib.rs:48:1
   |
48 | fn parse_method_calls<'a>(lang_server_trait: &'a ItemTrait) -> Vec<MethodCall<'a>> {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(clippy::needless_lifetimes)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
```

Crate checked with:
* `cargo +nightly udeps` => "All deps seem to have been used."
* `cargo audit` => "Success No vulnerable packages found"
* `cargo outdated` => "All dependencies are up to date, yay!" (2021-04-08)
