### PR TITLE
Support LSP version 3.16.0

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -123,7 +123,7 @@ impl Client {
     ///
     /// # Initialization
     ///
-    /// If the request is sent to client before the server has been initialized, this will
+    /// If the request is sent to the client before the server has been initialized, this will
     /// immediately return `Err` with JSON-RPC error code `-32002` ([read more]).
     ///
     /// [read more]: https://microsoft.github.io/language-server-protocol/specification#initialize
@@ -140,7 +140,7 @@ impl Client {
     ///
     /// # Initialization
     ///
-    /// If the request is sent to client before the server has been initialized, this will
+    /// If the request is sent to the client before the server has been initialized, this will
     /// immediately return `Err` with JSON-RPC error code `-32002` ([read more]).
     ///
     /// [read more]: https://microsoft.github.io/language-server-protocol/specification#initialize
@@ -162,7 +162,7 @@ impl Client {
     ///
     /// # Initialization
     ///
-    /// If the request is sent to client before the server has been initialized, this will
+    /// If the request is sent to the client before the server has been initialized, this will
     /// immediately return `Err` with JSON-RPC error code `-32002` ([read more]).
     ///
     /// [read more]: https://microsoft.github.io/language-server-protocol/specification#initialize
@@ -190,7 +190,7 @@ impl Client {
     ///
     /// # Initialization
     ///
-    /// If the request is sent to client before the server has been initialized, this will
+    /// If the request is sent to the client before the server has been initialized, this will
     /// immediately return `Err` with JSON-RPC error code `-32002` ([read more]).
     ///
     /// [read more]: https://microsoft.github.io/language-server-protocol/specification#initialize
@@ -212,7 +212,7 @@ impl Client {
     ///
     /// # Initialization
     ///
-    /// If the request is sent to client before the server has been initialized, this will
+    /// If the request is sent to the client before the server has been initialized, this will
     /// immediately return `Err` with JSON-RPC error code `-32002` ([read more]).
     ///
     /// [read more]: https://microsoft.github.io/language-server-protocol/specification#initialize
@@ -243,6 +243,33 @@ impl Client {
             uri, diags, version,
         ))
         .await;
+    }
+
+    /// Asks the client to refresh the code lenses currently shown in editors. As a result, the
+    /// client should ask the server to recompute the code lenses for these editors.
+    ///
+    /// This is useful if a server detects a configuration change which requires a re-calculation
+    /// of all code lenses.
+    ///
+    /// Note that the client still has the freedom to delay the re-calculation of the code lenses
+    /// if for example an editor is currently not visible.
+    ///
+    /// This corresponds to the [`workspace/codeLens/refresh`] request.
+    ///
+    /// [`workspace/codeLens/refresh`]: https://microsoft.github.io/language-server-protocol/specification#codeLens_refresh
+    ///
+    /// # Initialization
+    ///
+    /// If the request is sent to the client before the server has been initialized, this will
+    /// immediately return `Err` with JSON-RPC error code `-32002` ([read more]).
+    ///
+    /// [read more]: https://microsoft.github.io/language-server-protocol/specification#initialize
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    pub async fn code_lens_refresh(&self) -> Result<()> {
+        self.send_request_initialized::<CodeLensRefresh>(()).await
     }
 
     /// Sends a custom notification to the client.

--- a/src/client.rs
+++ b/src/client.rs
@@ -272,6 +272,35 @@ impl Client {
         self.send_request_initialized::<CodeLensRefresh>(()).await
     }
 
+    /// Asks the client to refresh the editors for which this server provides semantic tokens. As a
+    /// result, the client should ask the server to recompute the semantic tokens for these
+    /// editors.
+    ///
+    /// This is useful if a server detects a project-wide configuration change which requires a
+    /// re-calculation of all semantic tokens.
+    ///
+    /// Note that the client still has the freedom to delay the re-calculation of the semantic
+    /// tokens if for example an editor is currently not visible.
+    ///
+    /// This corresponds to the [`workspace/semanticTokens/refresh`] notification.
+    ///
+    /// [`workspace/semanticTokens/refresh`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_semanticTokens
+    ///
+    /// # Initialization
+    ///
+    /// If the request is sent to the client before the server has been initialized, this will
+    /// immediately return `Err` with JSON-RPC error code `-32002` ([read more]).
+    ///
+    /// [read more]: https://microsoft.github.io/language-server-protocol/specification#initialize
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    pub async fn semantic_tokens_refresh(&self) -> Result<()> {
+        self.send_request_initialized::<SemanticTokensRefesh>(())
+            .await
+    }
+
     /// Sends a custom notification to the client.
     ///
     /// # Initialization

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1023,6 +1023,36 @@ pub trait LanguageServer: Send + Sync + 'static {
         error!("Got a textDocument/linkedEditingRange request, but it is not implemented");
         Err(Error::method_not_found())
     }
+
+    /// The [`textDocument/moniker`] request is sent from the client to the server to get the
+    /// symbol monikers for a given text document position.
+    ///
+    /// [`textDocument/moniker`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_moniker
+    ///
+    /// An array of `Moniker` types is returned as response to indicate possible monikers at the
+    /// given location. If no monikers can be calculated, `Some(vec![])` or `None` should be
+    /// returned.
+    ///
+    /// # Concept
+    ///
+    /// The Language Server Index Format (LSIF) introduced the concept of _symbol monikers_ to help
+    /// associate symbols across different indexes. This request adds capability for LSP server
+    /// implementations to provide the same symbol moniker information given a text document
+    /// position.
+    ///
+    /// Clients can utilize this method to get the moniker at the current location in a file the
+    /// user is editing and do further code navigation queries in other services that rely on LSIF
+    /// indexes and link symbols together.
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    #[rpc(name = "textDocument/moniker")]
+    async fn moniker(&self, params: MonikerParams) -> Result<Option<Vec<Moniker>>> {
+        let _ = params;
+        error!("Got a textDocument/moniker request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
 }
 
 fn _assert_object_safe() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -622,7 +622,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     ///
     /// # Compatibility
     ///
-    /// Since version 3.8.0: support for `CodeAction` literals to enable the following scenarios:
+    /// Since version 3.8.0: support for [`CodeAction`] literals to enable the following scenarios:
     ///
     /// * The ability to directly return a workspace edit from the code action request.
     ///   This avoids having another server roundtrip to execute an actual code action.
@@ -640,6 +640,25 @@ pub trait LanguageServer: Send + Sync + 'static {
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
         let _ = params;
         error!("Got a textDocument/codeAction request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
+    /// The [`codeAction/resolve`] request is sent from the client to the server to resolve
+    /// additional information for a given code action.
+    ///
+    /// [`codeAction/resolve`]: https://microsoft.github.io/language-server-protocol/specification#codeAction_resolve
+    ///
+    /// This is usually used to compute the edit property of a [`CodeAction`] to avoid its
+    /// unnecessary computation during the [`textDocument/codeAction`](#method.code_action)
+    /// request.
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    #[rpc(name = "codeAction/resolve")]
+    async fn code_action_resolve(&self, params: CodeAction) -> Result<CodeAction> {
+        let _ = params;
+        error!("Got a codeAction/resolve request, but it is not implemented");
         Err(Error::method_not_found())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,97 @@ pub trait LanguageServer: Send + Sync + 'static {
         Err(Error::method_not_found())
     }
 
+    /// The [`workspace/willCreateFiles`] request is sent from the client to the server before
+    /// files are actually created as long as the creation is triggered from within the client.
+    ///
+    /// The request can return a `WorkspaceEdit` which will be applied to workspace before the
+    /// files are created. Please note that clients might drop results if computing the edit took
+    /// too long or if a server constantly fails on this request. This is done to keep creates fast
+    /// and reliable.
+    ///
+    /// [`workspace/willCreateFiles`]: https://microsoft.github.io/language-server-protocol/specification#workspace_willCreateFiles
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    #[rpc(name = "workspace/willCreateFiles")]
+    async fn will_create_files(&self, params: CreateFilesParams) -> Result<Option<WorkspaceEdit>> {
+        let _ = params;
+        error!("Got a workspace/willCreateFiles request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
+    /// The [`workspace/didCreateFiles`] request is sent from the client to the server when files
+    /// were created from within the client.
+    ///
+    /// [`workspace/didCreateFiles`]: https://microsoft.github.io/language-server-protocol/specification#workspace_didCreateFiles
+    #[rpc(name = "workspace/didCreateFiles")]
+    async fn did_create_files(&self, params: CreateFilesParams) {
+        let _ = params;
+        warn!("Got a workspace/didCreateFiles notification, but it is not implemented");
+    }
+
+    /// The [`workspace/willRenameFiles`] request is sent from the client to the server before
+    /// files are actually renamed as long as the rename is triggered from within the client.
+    ///
+    /// The request can return a `WorkspaceEdit` which will be applied to workspace before the
+    /// files are renamed. Please note that clients might drop results if computing the edit took
+    /// too long or if a server constantly fails on this request. This is done to keep creates fast
+    /// and reliable.
+    ///
+    /// [`workspace/willRenameFiles`]: https://microsoft.github.io/language-server-protocol/specification#workspace_willRenameFiles
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    #[rpc(name = "workspace/willRenameFiles")]
+    async fn will_rename_files(&self, params: RenameFilesParams) -> Result<Option<WorkspaceEdit>> {
+        let _ = params;
+        error!("Got a workspace/willRenameFiles request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
+    /// The [`workspace/didRenameFiles`] notification is sent from the client to the server when
+    /// files were renamed from within the client.
+    ///
+    /// [`workspace/didRenameFiles`]: https://microsoft.github.io/language-server-protocol/specification#workspace_didRenameFiles
+    #[rpc(name = "workspace/didRenameFiles")]
+    async fn did_rename_files(&self, params: RenameFilesParams) {
+        let _ = params;
+        warn!("Got a workspace/didRenameFiles notification, but it is not implemented");
+    }
+
+    /// The [`workspace/willDeleteFiles`] request is sent from the client to the server before
+    /// files are actually deleted as long as the deletion is triggered from within the client
+    /// either by a user action or by applying a workspace edit.
+    ///
+    /// The request can return a `WorkspaceEdit` which will be applied to workspace before the
+    /// files are deleted. Please note that clients might drop results if computing the edit took
+    /// too long or if a server constantly fails on this request. This is done to keep deletions
+    /// fast and reliable.
+    ///
+    /// [`workspace/willDeleteFiles`]: https://microsoft.github.io/language-server-protocol/specification#workspace_willDeleteFiles
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    #[rpc(name = "workspace/willDeleteFiles")]
+    async fn will_delete_files(&self, params: DeleteFilesParams) -> Result<Option<WorkspaceEdit>> {
+        let _ = params;
+        error!("Got a workspace/willDeleteFiles request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
+    /// The [`workspace/didDeleteFiles`] notification is sent from the client to the server when
+    /// files were deleted from within the client.
+    ///
+    /// [`workspace/didDeleteFiles`]: https://microsoft.github.io/language-server-protocol/specification#workspace_didDeleteFiles
+    #[rpc(name = "workspace/didDeleteFiles")]
+    async fn did_delete_files(&self, params: DeleteFilesParams) {
+        let _ = params;
+        warn!("Got a workspace/didDeleteFiles notification, but it is not implemented");
+    }
+
     /// The [`textDocument/didOpen`] notification is sent from the client to the server to signal
     /// that a new text document has been opened by the client.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -998,6 +998,31 @@ pub trait LanguageServer: Send + Sync + 'static {
         error!("Got a textDocument/semanticTokens/range request, but it is not implemented");
         Err(Error::method_not_found())
     }
+
+    /// The [`textDocument/linkedEditingRange`] request is sent from the client to the server to
+    /// return for a given position in a document the range of the symbol at the position and all
+    /// ranges that have the same content.
+    ///
+    /// [`textDocument/linkedEditingRange`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_linkedEditingRange
+    ///
+    /// Optionally a word pattern can be returned to describe valid contents.
+    ///
+    /// A rename to one of the ranges can be applied to all other ranges if the new content is
+    /// valid. If no result-specific word pattern is provided, the word pattern from the client's
+    /// language configuration is used.
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    #[rpc(name = "textDocument/linkedEditingRange")]
+    async fn linked_editing_range(
+        &self,
+        params: LinkedEditingRangeParams,
+    ) -> Result<Option<LinkedEditingRanges>> {
+        let _ = params;
+        error!("Got a textDocument/linkedEditingRange request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
 }
 
 fn _assert_object_safe() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// notification.
     ///
     /// [`workspace/didChangeWorkspaceFolders`]: https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeWorkspaceFolders
-    /// [`initialize`]: #tymethod.initialize
+    /// [`initialize`]: #method.initialize
     #[rpc(name = "workspace/didChangeWorkspaceFolders")]
     async fn did_change_workspace_folders(&self, params: DidChangeWorkspaceFoldersParams) {
         let _ = params;
@@ -181,7 +181,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// `Client::register_capability()`.
     ///
     /// [`workspace/didChangeWatchedFiles`]: https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeConfiguration
-    /// [`initialized`]: #tymethod.initialized
+    /// [`initialized`]: #method.initialized
     #[rpc(name = "workspace/didChangeWatchedFiles")]
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
         let _ = params;
@@ -454,7 +454,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// ```
     ///
     /// [`GotoDefinitionResponse::Link`]: https://docs.rs/lsp-types/0.74.0/lsp_types/enum.GotoDefinitionResponse.html#variant.Link
-    /// [`initialize`]: #tymethod.initialize
+    /// [`initialize`]: #method.initialize
     #[rpc(name = "textDocument/declaration")]
     async fn goto_declaration(
         &self,
@@ -481,7 +481,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// ```
     ///
     /// [`GotoDefinitionResponse::Link`]: https://docs.rs/lsp-types/0.74.0/lsp_types/enum.GotoDefinitionResponse.html#variant.Link
-    /// [`initialize`]: #tymethod.initialize
+    /// [`initialize`]: #method.initialize
     #[rpc(name = "textDocument/definition")]
     async fn goto_definition(
         &self,
@@ -510,7 +510,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// ```
     ///
     /// [`GotoDefinitionResponse::Link`]: https://docs.rs/lsp-types/0.74.0/lsp_types/enum.GotoDefinitionResponse.html#variant.Link
-    /// [`initialize`]: #tymethod.initialize
+    /// [`initialize`]: #method.initialize
     #[rpc(name = "textDocument/typeDefinition")]
     async fn goto_type_definition(
         &self,
@@ -539,7 +539,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// ```
     ///
     /// [`GotoImplementationResponse::Link`]: https://docs.rs/lsp-types/0.74.0/lsp_types/enum.GotoDefinitionResponse.html#variant.Link
-    /// [`initialize`]: #tymethod.initialize
+    /// [`initialize`]: #method.initialize
     #[rpc(name = "textDocument/implementation")]
     async fn goto_implementation(
         &self,
@@ -683,7 +683,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// InitializeParams::capabilities::text_document::document_link::tooltip_support
     /// ```
     ///
-    /// [`initialize`]: #tymethod.initialize
+    /// [`initialize`]: #method.initialize
     #[rpc(name = "textDocument/documentLink")]
     async fn document_link(&self, params: DocumentLinkParams) -> Result<Option<Vec<DocumentLink>>> {
         let _ = params;
@@ -741,7 +741,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// This request has no special capabilities and registration options since it is sent as a
     /// resolve request for the [`textDocument/documentColor`] request.
     ///
-    /// [`textDocument/documentColor`]: #tymethod.document_color
+    /// [`textDocument/documentColor`]: #method.document_color
     #[rpc(name = "textDocument/colorPresentation")]
     async fn color_presentation(
         &self,
@@ -855,6 +855,76 @@ pub trait LanguageServer: Send + Sync + 'static {
     ) -> Result<Option<Vec<SelectionRange>>> {
         let _ = params;
         error!("Got a textDocument/selectionRange request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
+    /// The [`textDocument/prepareCallHierarchy`] request is sent from the client to the server to
+    /// return a call hierarchy for the language element of given text document positions.
+    ///
+    /// [`textDocument/prepareCallHierarchy`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_prepareCallHierarchy
+    ///
+    /// The call hierarchy requests are executed in two steps:
+    ///
+    /// 1. First, a call hierarchy item is resolved for the given text document position (this
+    ///    method).
+    /// 2. For a call hierarchy item, the incoming or outgoing call hierarchy items are resolved
+    ///    inside [`incoming_calls()`](#method.incoming_calls) and
+    ///    [`outgoing_calls()`](#method.outgoing_calls), respectively.
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    #[rpc(name = "textDocument/prepareCallHierarchy")]
+    async fn prepare_call_hierarchy(
+        &self,
+        params: CallHierarchyPrepareParams,
+    ) -> Result<Option<Vec<CallHierarchyItem>>> {
+        let _ = params;
+        error!("Got a textDocument/prepareCallHierarchy request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
+    /// The [`callHierarchy/incomingCalls`] request is sent from the client to the server to
+    /// resolve **incoming** calls for a given call hierarchy item.
+    ///
+    /// The request doesn't define its own client and server capabilities. It is only issued if a
+    /// server registers for the [`textDocument/prepareCallHierarchy`] request.
+    ///
+    /// [`callHierarchy/incomingCalls`]: https://microsoft.github.io/language-server-protocol/specification#callHierarchy_incomingCalls
+    /// [`textDocument/prepareCallHierarchy`]: #method.prepare_call_hierarchy
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    #[rpc(name = "callHierarchy/incomingCalls")]
+    async fn incoming_calls(
+        &self,
+        params: CallHierarchyIncomingCallsParams,
+    ) -> Result<Option<Vec<CallHierarchyIncomingCall>>> {
+        let _ = params;
+        error!("Got a callHierarchy/incomingCalls request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
+    /// The [`callHierarchy/outgoingCalls`] request is sent from the client to the server to
+    /// resolve **outgoing** calls for a given call hierarchy item.
+    ///
+    /// The request doesn't define its own client and server capabilities. It is only issued if a
+    /// server registers for the [`textDocument/prepareCallHierarchy`] request.
+    ///
+    /// [`callHierarchy/outgoingCalls`]: https://microsoft.github.io/language-server-protocol/specification#callHierarchy_outgoingCalls
+    /// [`textDocument/prepareCallHierarchy`]: #method.prepare_call_hierarchy
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    #[rpc(name = "callHierarchy/outgoingCalls")]
+    async fn outgoing_calls(
+        &self,
+        params: CallHierarchyOutgoingCallsParams,
+    ) -> Result<Option<Vec<CallHierarchyOutgoingCall>>> {
+        let _ = params;
+        error!("Got a callHierarchy/outgoingCalls request, but it is not implemented");
         Err(Error::method_not_found())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -927,6 +927,77 @@ pub trait LanguageServer: Send + Sync + 'static {
         error!("Got a callHierarchy/outgoingCalls request, but it is not implemented");
         Err(Error::method_not_found())
     }
+
+    /// The [`textDocument/semanticTokens/full`] request is sent from the client to the server to
+    /// resolve the semantic tokens of a given file.
+    ///
+    /// Semantic tokens are used to add additional color information to a file that depends on
+    /// language specific symbol information. A semantic token request usually produces a large
+    /// result. The protocol therefore supports encoding tokens with numbers. In addition, optional
+    /// support for deltas is available, i.e. [`semantic_tokens_full_delta`].
+    ///
+    /// [`textDocument/semanticTokens/full`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_semanticTokens
+    /// [`semantic_tokens_full_delta`]: #method.semantic_tokens_full_delta
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    #[rpc(name = "textDocument/semanticTokens/full")]
+    async fn semantic_tokens_full(
+        &self,
+        params: SemanticTokensParams,
+    ) -> Result<Option<SemanticTokensResult>> {
+        let _ = params;
+        error!("Got a textDocument/semanticTokens/full request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
+    /// The [`textDocument/semanticTokens/full/delta`] request is sent from the client to the server to
+    /// resolve the semantic tokens of a given file, **returning only the delta**.
+    ///
+    /// Similar to [`semantic_tokens_full`](#method.semantic_tokens_full), except it returns a
+    /// sequence of [`SemanticTokensEdit`] to transform a previous result into a new result.
+    ///
+    /// [`textDocument/semanticTokens/full/delta`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_semanticTokens
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    #[rpc(name = "textDocument/semanticTokens/full/delta")]
+    async fn semantic_tokens_full_delta(
+        &self,
+        params: SemanticTokensDeltaParams,
+    ) -> Result<Option<SemanticTokensFullDeltaResult>> {
+        let _ = params;
+        error!("Got a textDocument/semanticTokens/full/delta request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
+    /// The [`textDocument/semanticTokens/range`] request is sent from the client to the server to
+    /// resolve the semantic tokens **for the visible range** of a given file.
+    ///
+    /// When a user opens a file, it can be beneficial to only compute the semantic tokens for the
+    /// visible range (faster rendering of the tokens in the user interface). If a server can
+    /// compute these tokens faster than for the whole file, it can implement this method to handle
+    /// this special case.
+    ///
+    /// See [`semantic_tokens_full`] for more details.
+    ///
+    /// [`textDocument/semanticTokens/range`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_semanticTokens
+    /// [`semantic_tokens_full`]: #method.semantic_tokens_full
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.16.0.
+    #[rpc(name = "textDocument/semanticTokens/range")]
+    async fn semantic_tokens_range(
+        &self,
+        params: SemanticTokensRangeParams,
+    ) -> Result<Option<SemanticTokensRangeResult>> {
+        let _ = params;
+        error!("Got a textDocument/semanticTokens/range request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
 }
 
 fn _assert_object_safe() {


### PR DESCRIPTION
### Added

* Implement `workspace/willCreateFiles` server request.
* Implement `workspace/willRenameFiles` server request.
* Implement `workspace/willDeleteFiles` server request.
* Implement `workspace/didCreateFiles` server notification.
* Implement `workspace/didRenameFiles` server notification.
* Implement `workspace/didDeleteFiles` server notification.
* Implement `workspace/codeLens/refresh` client request.
* Implement call hierarchy server requests.
* Implement semantic tokens server and client requests.
* Implement `textDocument/linkedEditingRange` server request.
* Implement `textDocument/moniker` request.
* Implement `codeAction/resolve` request.

### Fixed

* Fix several broken intra-doc links.