### PR TITLE
Update tokio dev-dependency to 1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tower-service = "0.3"
 
 [dev-dependencies]
 env_logger = "0.8.3"
-tokio = { version = "1.4.0", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "time"] }
+tokio = { version = "1.6", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "time"] }
 tower-test = "0.4"
 
 [workspace]


### PR DESCRIPTION
### Changed

* Update `tokio` dev-dependency to 1.6.

This makes the `tokio` versions specified in the `Cargo.toml` consistent across the board. Since this change only affects tests and examples, this PR need not trigger another `tower-lsp` version bump.