### PR TITLE
Update LICENSE-MIT copyright year

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020 Eyal Kalderon
+Copyright (c) 2021 Eyal Kalderon
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
### Changed

* Update `LICENSE-MIT` copyright year from 2020 to 2021.

This is an oversight from #276, but is ultimately harmless.