### PR TITLE
Fix server support for $/cancelRequest

### DIFF
--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -10,6 +10,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 
 use lsp_types::notification::Notification;
 use lsp_types::request::Request;
+use lsp_types::NumberOrString;
 use serde::de::{self, Deserializer};
 use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
@@ -38,6 +39,15 @@ impl Display for Id {
         match self {
             Id::Number(id) => Display::fmt(id, f),
             Id::String(id) => Debug::fmt(id, f),
+        }
+    }
+}
+
+impl From<NumberOrString> for Id {
+    fn from(num_or_str: NumberOrString) -> Self {
+        match num_or_str {
+            NumberOrString::Number(num) => Id::Number(num as u64),
+            NumberOrString::String(s) => Id::String(s),
         }
     }
 }

--- a/tower-lsp-macros/src/lib.rs
+++ b/tower-lsp-macros/src/lib.rs
@@ -253,7 +253,7 @@ fn gen_server_router(trait_name: &syn::Ident, methods: &[MethodCall]) -> proc_ma
             enum ServerMethod {
                 #variants
                 #[serde(rename = "$/cancelRequest")]
-                CancelRequest { id: Id },
+                CancelRequest { params: CancelParams },
                 #[serde(rename = "exit")]
                 Exit,
             }
@@ -316,8 +316,8 @@ fn gen_server_router(trait_name: &syn::Ident, methods: &[MethodCall]) -> proc_ma
 
                 match (method, state.get()) {
                     #route_match_arms
-                    (ServerMethod::CancelRequest { id }, State::Initialized) => {
-                        pending.cancel(&id);
+                    (ServerMethod::CancelRequest { params }, State::Initialized) => {
+                        pending.cancel(&params.id.into());
                         future::ok(None).boxed()
                     }
                     (ServerMethod::Exit, _) => {


### PR DESCRIPTION
### Added

* Implement conversion between `lsp_types::NumberOrString` and `tower_lsp::jsonrpc::Id`.
* Add new `cancels_pending_requests` unit test.

### Fixed

* Fix `RequestKind::CancelRequest` struct-like variant definition.

Closes #281.