### PR TITLE
Prepare release 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.14.1] - 2021-05-21
+
+### Fixed
+
+* Fix regression in server-side `$/cancelRequest` support (PR #280).
+
 ## [0.14.0] - 2021-05-20
 
 ### Added
@@ -415,7 +421,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * `textDocument/hover`
   * `textDocument/documentHighlight`
 
-[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.14.1...HEAD
+[0.14.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.13.3...v0.14.0
 [0.13.3]: https://github.com/ebkalderon/tower-lsp/compare/v0.13.2...v0.13.3
 [0.13.2]: https://github.com/ebkalderon/tower-lsp/compare/v0.13.1...v0.13.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 edition = "2018"
 description = "Language Server Protocol implementation based on Tower"
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = "1.6"
 tokio-util = { version = "0.6.5", features = ["codec"] }
-tower-lsp-macros = { version = "0.4", path = "./tower-lsp-macros" }
+tower-lsp-macros = { version = "0.4.1", path = "./tower-lsp-macros" }
 tower-service = "0.3"
 
 [dev-dependencies]

--- a/tower-lsp-macros/Cargo.toml
+++ b/tower-lsp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp-macros"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Internal procedural macros for tower-lsp"
 edition = "2018"


### PR DESCRIPTION
### Changed

* Update `CHANGELOG.md`.
* Bump crate version to 0.14.1.

This rapid release is necessary to get #280 out the door ASAP.