### PR TITLE
Support null and negative integer request IDs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 //! Types for sending data to and from the language client.
 
 use std::fmt::{self, Debug, Display, Formatter};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 use futures::channel::mpsc::Sender;
@@ -18,7 +18,7 @@ use super::{ServerState, State};
 
 struct ClientInner {
     sender: Sender<Outgoing>,
-    request_id: AtomicU64,
+    request_id: AtomicU32,
     pending_requests: Arc<ClientRequests>,
     state: Arc<ServerState>,
 }
@@ -43,7 +43,7 @@ impl Client {
         Client {
             inner: Arc::new(ClientInner {
                 sender,
-                request_id: AtomicU64::new(0),
+                request_id: AtomicU32::new(0),
                 pending_requests,
                 state,
             }),
@@ -356,7 +356,7 @@ impl Client {
         let id = self.inner.request_id.fetch_add(1, Ordering::Relaxed);
         let message = Outgoing::Request(ClientRequest::request::<R>(id, params));
 
-        let response_waiter = self.inner.pending_requests.wait(Id::Number(id));
+        let response_waiter = self.inner.pending_requests.wait(Id::Number(id as i64));
 
         if self.inner.sender.clone().send(message).await.is_err() {
             error!("failed to send request");

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -14,7 +14,7 @@ use tokio_util::codec::{FramedRead, FramedWrite};
 use tower_service::Service;
 
 use super::codec::LanguageServerCodec;
-use super::jsonrpc::{self, Incoming, Outgoing, Response};
+use super::jsonrpc::{self, Id, Incoming, Outgoing, Response};
 
 /// Server for processing requests and responses on standard I/O or TCP.
 #[derive(Debug)]
@@ -109,7 +109,7 @@ where
                     Ok(req) => req,
                     Err(err) => {
                         error!("failed to decode message: {}", err);
-                        let response = Response::error(None, jsonrpc::Error::parse_error());
+                        let response = Response::error(Id::Null, jsonrpc::Error::parse_error());
                         let response_fut = future::ready(Some(Outgoing::Response(response)));
                         sender.send(Either::Right(response_fut)).await.unwrap();
                         continue;


### PR DESCRIPTION
### Added

* Add a new `Id::Null` enum variant.
* Implement `Default` for `Id`.
* Add unit tests to ensure `null` and negative integer request IDs parse successfully.

### Changed

* Change `Id::Number(u64)` to `Id::Number(i64)`.
* Change `Response::error()` constructor to accept `Id` instead of `Option<Id>`.
* Change `Response::id()` method to return `&Id` instead of `Option<&Id>`.
* Change `Response::into_parts()` method to return `(Id, _)` instead of `(Option<Id>, _)`
* Use `std::sync::atomic::AtomicU32` to track client request IDs instead of `AtomicU64`. This ensures the incrementing IDs will always cast losslessly into an `i64` primitive data type.

Both of these request ID types are rare and bizarre and their use is generally discouraged by the JSON-RPC 2.0 spec, but are nonetheless permitted by the standard. Since we wish `tower-lsp` to be compatible with as many JSON-RPC client libraries as possible, we must support parsing `null` and negative integer request IDs, even if we never emit them ourselves.