### PR TITLE
Fix continue-on-error behavior in GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,8 +25,8 @@ jobs:
         rustup component add rustfmt
         cargo fmt --all -- --check
     - name: Build
-      continue-on-error: ${{ matrix.continue-on-error }}
+      continue-on-error: ${{ matrix.continue-on-error || false }}
       run: cargo build --all --verbose
     - name: Run tests
-      continue-on-error: ${{ matrix.continue-on-error }}
+      continue-on-error: ${{ matrix.continue-on-error || false }}
       run: cargo test --all --verbose

--- a/src/client.rs
+++ b/src/client.rs
@@ -426,7 +426,7 @@ mod tests {
         assert_eq!(messages, vec![Outgoing::Request(expected)]);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn log_message() {
         let (typ, msg) = (MessageType::Log, "foo bar".to_owned());
         let expected = ClientRequest::notification::<LogMessage>(LogMessageParams {
@@ -437,7 +437,7 @@ mod tests {
         assert_client_messages(|p| async move { p.log_message(typ, msg).await }, expected).await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn show_message() {
         let (typ, msg) = (MessageType::Log, "foo bar".to_owned());
         let expected = ClientRequest::notification::<ShowMessage>(ShowMessageParams {
@@ -448,7 +448,7 @@ mod tests {
         assert_client_messages(|p| async move { p.show_message(typ, msg).await }, expected).await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn telemetry_event() {
         let null = json!(null);
         let expected = ClientRequest::notification::<TelemetryEvent>(null.clone());
@@ -468,7 +468,7 @@ mod tests {
         assert_client_messages(|p| async move { p.telemetry_event(other).await }, expected).await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn publish_diagnostics() {
         let uri: Url = "file:///path/to/file".parse().unwrap();
         let diagnostics = vec![Diagnostic::new_simple(Default::default(), "example".into())];

--- a/src/jsonrpc/pending.rs
+++ b/src/jsonrpc/pending.rs
@@ -146,7 +146,7 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn executes_server_request() {
         let pending = ServerRequests::new();
 
@@ -156,7 +156,7 @@ mod tests {
         assert_eq!(response, Response::ok(id, json!({})));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn cancels_server_request() {
         let pending = ServerRequests::new();
 
@@ -173,7 +173,7 @@ mod tests {
         assert_eq!(res, Response::error(Some(id), Error::request_cancelled()));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn waits_for_client_response() {
         let pending = ClientRequests::new();
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -179,7 +179,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn initializes_only_once() {
         let (service, _) = LspService::new(|_| Mock::default());
         let mut service = Spawn::new(service);
@@ -196,7 +196,7 @@ mod tests {
         assert_eq!(service.call(initialize).await, Ok(Some(err)));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn refuses_requests_after_shutdown() {
         let (service, _) = LspService::new(|_| Mock::default());
         let mut service = Spawn::new(service);
@@ -219,7 +219,7 @@ mod tests {
         assert_eq!(service.call(shutdown).await, Ok(Some(err)));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn exit_notification() {
         let (service, _) = LspService::new(|_| Mock::default());
         let mut service = Spawn::new(service);
@@ -236,7 +236,7 @@ mod tests {
         assert_eq!(service.call(initialized).await, Err(ExitedError));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn cancels_pending_requests() {
         let (service, _) = LspService::new(|_| Mock::default());
         let mut service = Spawn::new(service);

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -203,7 +203,7 @@ mod tests {
         (Cursor::new(mock_request()), Vec::new())
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn serves_on_stdio() {
         let (mut stdin, mut stdout) = mock_stdio();
         Server::new(&mut stdin, &mut stdout)
@@ -214,7 +214,7 @@ mod tests {
         assert_eq!(stdout, mock_response());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn interleaves_messages() {
         let message = Outgoing::Response(serde_json::from_str(RESPONSE).unwrap());
         let messages = stream::iter(vec![message]);
@@ -230,7 +230,7 @@ mod tests {
         assert_eq!(stdout, output);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn handles_invalid_json() {
         let invalid = r#"{"jsonrpc":"2.0","method":"#;
         let message = format!("Content-Length: {}\r\n\r\n{}", invalid.len(), invalid).into_bytes();


### PR DESCRIPTION
### Fixed

* Coerce `matrix.continue-on-error` to `bool` in the `rust.yml` workflow. Should fix the erroneous behavior seen in #285 during the macOS builds. See the first commit message for details.
* Switch all tests to `#[tokio::test(flavor = "current_thread")]` to fix failing macOS test jobs in CI.