### PR TITLE
Bump various dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust-version: [1.45.0, beta, nightly]
+        rust-version: [1.46.0, beta, nightly]
         include:
         - rust-version: nightly
           continue-on-error: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ exclude = ["./tower-lsp-macros"]
 
 [dependencies]
 async-trait = "0.1"
-auto_impl = "0.4"
+auto_impl = "0.5"
 bytes = "1.0.1"
-dashmap = "4.0.2"
+dashmap = "5.0.0"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 log = "0.4"
 lsp-types = "0.89.0"
-nom = { version = "6.1.2", default-features = false, features = ["std"] }
+nom = { version = "7.1.0", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = "1.6"
@@ -30,7 +30,7 @@ tower-lsp-macros = { version = "0.4.1", path = "./tower-lsp-macros" }
 tower-service = "0.3"
 
 [dev-dependencies]
-env_logger = "0.8.3"
+env_logger = "0.9.0"
 tokio = { version = "1.6", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "time"] }
 tower-test = "0.4"
 


### PR DESCRIPTION
nom 7.1.0 depends on rust 1.46.0, since it uses an `if` in  a `const fn`
so bump the rust version too.