### PR TITLE
Change minimum Rust version to 1.49.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust-version: [1.46.0, beta, nightly]
+        rust-version: [1.49.0, beta, nightly]
         include:
         - rust-version: nightly
           continue-on-error: true


### PR DESCRIPTION
### Fixes

* Update minimum supported Rust version in CI to 1.49.0. This is to fix some compile errors on `master` after merging #298.