### PR TITLE
Prepare release 0.15.1 (contains semver fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.15.0] - 2022-02-10
+## [0.15.1] - 2022-02-14
+
+### Fixed
+
+* Fix semver incompatibility in release of `tower-lsp-macros` (PR #306).
+  * Re-released `tower-lsp-macros` 0.4.2 -> 0.5.0.
+  * Re-released `tower-lsp` 0.15.0 -> 0.15.1.
+
+## [0.15.0] - 2022-02-10 [YANKED]
 
 ### Changed
 
@@ -435,7 +443,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * `textDocument/hover`
   * `textDocument/documentHighlight`
 
-[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.15.1...HEAD
+[0.15.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.13.3...v0.14.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 edition = "2018"
 description = "Language Server Protocol implementation based on Tower"
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = "1.6"
 tokio-util = { version = "0.7.0", features = ["codec"] }
-tower-lsp-macros = { version = "0.4.2", path = "./tower-lsp-macros" }
+tower-lsp-macros = { version = "0.5.0", path = "./tower-lsp-macros" }
 tower-service = "0.3"
 
 [dev-dependencies]

--- a/tower-lsp-macros/Cargo.toml
+++ b/tower-lsp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp-macros"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Internal procedural macros for tower-lsp"
 edition = "2018"


### PR DESCRIPTION
### Changed

* Re-release `tower-lsp-macros` 0.4.2 -> 0.5.0.
* Re-release `tower-lsp` 0.15.0 -> 0.15.1.
* Update `CHANGELOG.md`.

The intention is to yank the preceding versions from Crates.io to fix a semver incompatibility introduced in #285.

Fixes #305.