### PR TITLE
Address a few clippy lints

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets --workspace -- -D warnings
+          args: --all-targets -- -D warnings
 
   # verify that code is formatted
   cargo-fmt:

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -266,17 +266,17 @@ mod tests {
     #[test]
     fn encode_and_decode() {
         let decoded = r#"{"jsonrpc":"2.0","method":"exit"}"#;
-        let encoded = encode_message(None, &decoded);
+        let encoded = encode_message(None, decoded);
 
         let mut codec = LanguageServerCodec::default();
         let mut buffer = BytesMut::new();
-        let item: Value = serde_json::from_str(&decoded).unwrap();
+        let item: Value = serde_json::from_str(decoded).unwrap();
         codec.encode(item, &mut buffer).unwrap();
         assert_eq!(buffer, BytesMut::from(encoded.as_str()));
 
         let mut buffer = BytesMut::from(encoded.as_str());
         let message = codec.decode(&mut buffer).unwrap();
-        let decoded = serde_json::from_str(&decoded).unwrap();
+        let decoded = serde_json::from_str(decoded).unwrap();
         assert_eq!(message, Some(decoded));
     }
 
@@ -289,7 +289,7 @@ mod tests {
         let mut codec = LanguageServerCodec::default();
         let mut buffer = BytesMut::from(encoded.as_str());
         let message = codec.decode(&mut buffer).unwrap();
-        let decoded: Value = serde_json::from_str(&decoded).unwrap();
+        let decoded: Value = serde_json::from_str(decoded).unwrap();
         assert_eq!(message, Some(decoded));
     }
 
@@ -319,7 +319,7 @@ mod tests {
         }
 
         let message: Option<Value> = codec.decode(&mut buffer).unwrap();
-        let first_valid = serde_json::from_str(&decoded).unwrap();
+        let first_valid = serde_json::from_str(decoded).unwrap();
         assert_eq!(message, Some(first_valid));
 
         match codec.decode(&mut buffer) {
@@ -328,7 +328,7 @@ mod tests {
         }
 
         let message = codec.decode(&mut buffer).unwrap();
-        let second_valid = serde_json::from_str(&decoded).unwrap();
+        let second_valid = serde_json::from_str(decoded).unwrap();
         assert_eq!(message, Some(second_valid));
 
         let message = codec.decode(&mut buffer).unwrap();

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -130,6 +130,7 @@ enum ResponseKind {
 }
 
 /// An incoming JSON-RPC message.
+#[allow(clippy::large_enum_variant)] // Ignore for now, since this will be replaced soon.
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 #[cfg_attr(test, derive(Serialize))]
 #[serde(untagged)]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -188,8 +188,8 @@ mod tests {
 
     use super::*;
 
-    const REQUEST: &'static str = r#"{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}"#;
-    const RESPONSE: &'static str = r#"{"jsonrpc":"2.0","result":{"capabilities":{}},"id":1}"#;
+    const REQUEST: &str = r#"{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}"#;
+    const RESPONSE: &str = r#"{"jsonrpc":"2.0","result":{"capabilities":{}},"id":1}"#;
 
     #[derive(Debug)]
     struct MockService;

--- a/tower-lsp-macros/src/lib.rs
+++ b/tower-lsp-macros/src/lib.rs
@@ -116,10 +116,8 @@ fn gen_server_router(trait_name: &syn::Ident, methods: &[MethodCall]) -> proc_ma
     let id_match_arms: proc_macro2::TokenStream = methods
         .iter()
         .zip(variant_names.iter())
-        .filter_map(|(method, var_name)| match method.result {
-            Some(_) => Some(quote!(ServerMethod::#var_name { ref id, .. } => Some(id),)),
-            None => None,
-        })
+        .filter_map(|(method, var_name)| method.result.map(|_| var_name))
+        .map(|var_name| quote!(ServerMethod::#var_name { ref id, .. } => Some(id),))
         .collect();
 
     let route_match_arms: proc_macro2::TokenStream = methods


### PR DESCRIPTION
### Changed

* Address `clippy` lints in `tower-lsp-macros`.
* Address `clippy` lints in `tower-lsp`.

### Removed

* Remove unnecessary `--workspace` argument from `clippy` CI job.

These were identified by the new CI job added in #309.