### PR TITLE
Improve GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: main
+name: ci
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   cargo-test:
-    name: Run cargo test (${{ matrix.os }} / ${{ matrix.rust-version }} / ${{ matrix.runtime }})
+    name: cargo test (${{ matrix.os }} / ${{ matrix.rust-version }} / ${{ matrix.runtime }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -37,7 +37,7 @@ jobs:
         args: --workspace --no-default-features --features ${{ matrix.runtime }}
 
   cargo-audit:
-    name: Run cargo audit
+    name: cargo audit
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -46,7 +46,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
   cargo-clippy:
-    name: Run cargo clippy
+    name: cargo clippy
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
         args: --all-targets -- -D warnings
 
   cargo-fmt:
-    name: Run cargo fmt
+    name: cargo fmt
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,10 @@ name: main
 on:
   push:
     branches:
-      - master
+    - master
   pull_request:
     branches:
-      - master
+    - master
 
 jobs:
   # verify that Cargo.lock passes audit
@@ -43,19 +43,19 @@ jobs:
     env:
       RUST_TOOLCHAIN: stable
     steps:
-      - uses: actions/checkout@v2
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: clippy
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
-      - name: Run cargo clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets -- -D warnings
+    - uses: actions/checkout@v2
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        components: clippy
+        toolchain: ${{ env.RUST_TOOLCHAIN }}
+        override: true
+    - name: Run cargo clippy
+      uses: actions-rs/clippy-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: --all-targets -- -D warnings
 
   # verify that code is formatted
   cargo-fmt:
@@ -65,20 +65,20 @@ jobs:
     env:
       RUST_TOOLCHAIN: nightly
     steps:
-      - uses: actions/checkout@v2
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: rustfmt
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          command: fmt
-          args: --all -- --check
+    - uses: actions/checkout@v2
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        components: rustfmt
+        toolchain: ${{ env.RUST_TOOLCHAIN }}
+        override: true
+    - name: Run cargo fmt
+      uses: actions-rs/cargo@v1
+      with:
+        toolchain: ${{ env.RUST_TOOLCHAIN }}
+        command: fmt
+        args: --all -- --check
 
   # verify that tests pass
   cargo-test-agnostic:
@@ -93,19 +93,19 @@ jobs:
           continue-on-error: true
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust-version }}
-          override: yes
-      - name: Run cargo test
-        continue-on-error: ${{ matrix.continue-on-error || false }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --no-default-features --features runtime-agnostic
+    - uses: actions/checkout@v2
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: ${{ matrix.rust-version }}
+        override: yes
+    - name: Run cargo test
+      continue-on-error: ${{ matrix.continue-on-error || false }}
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --no-default-features --features runtime-agnostic
 
   # verify that tests pass
   cargo-test-tokio:
@@ -120,16 +120,16 @@ jobs:
           continue-on-error: true
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust-version }}
-          override: yes
-      - name: Run cargo test
-        continue-on-error: ${{ matrix.continue-on-error || false }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --no-default-features --features runtime-tokio
+    - uses: actions/checkout@v2
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: ${{ matrix.rust-version }}
+        override: yes
+    - name: Run cargo test
+      continue-on-error: ${{ matrix.continue-on-error || false }}
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --no-default-features --features runtime-tokio

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
     - master
+    - release/*
   pull_request:
     branches:
     - master
+    - release/*
 
 jobs:
   # verify that Cargo.lock passes audit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,6 @@ jobs:
         command: test
         args: --workspace --no-default-features --features ${{ matrix.runtime }}
 
-  # verify that Cargo.lock passes audit
   cargo-audit:
     name: Run cargo audit
     runs-on: ubuntu-latest
@@ -61,7 +60,6 @@ jobs:
     - run: echo "${{ runner.tool_cache }}/cargo-audit/bin" >> $GITHUB_PATH
     - run: cargo audit
 
-  # verify that project passes clippy lints
   cargo-clippy:
     name: Run cargo clippy
     runs-on: ubuntu-latest
@@ -82,7 +80,6 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: --all-targets -- -D warnings
 
-  # verify that code is formatted
   cargo-fmt:
     name: Run cargo fmt
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,25 +40,10 @@ jobs:
     name: Run cargo audit
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Fetch latest release version of cargo-audit
-      run: |
-        mkdir -p .github/caching
-        cargo search cargo-audit | grep '^cargo-audit' | awk '{gsub(/"/,"",$3); print $3}' > .github/caching/cargo-audit.lock
-    - name: Cache cargo-audit/bin
-      id: cache-cargo-audit
-      uses: actions/cache@v1
+    - uses: actions/checkout@v1
+    - uses: actions-rs/audit-check@v1
       with:
-        path: ${{ runner.tool_cache }}/cargo-audit/bin
-        key: cargo-audit-bin-${{ hashFiles('.github/caching/cargo-audit.lock') }}
-    - name: Install cargo-audit
-      if: "steps.cache-cargo-audit.outputs.cache-hit != 'true'"
-      uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: --root ${{ runner.tool_cache }}/cargo-audit --force cargo-audit
-    - run: echo "${{ runner.tool_cache }}/cargo-audit/bin" >> $GITHUB_PATH
-    - run: cargo audit
+        token: ${{ secrets.GITHUB_TOKEN }}
 
   cargo-clippy:
     name: Run cargo clippy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,17 +48,14 @@ jobs:
   cargo-clippy:
     name: Run cargo clippy
     runs-on: ubuntu-latest
-    env:
-      RUST_TOOLCHAIN: stable
     steps:
     - uses: actions/checkout@v2
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
+        toolchain: stable
         components: clippy
-        toolchain: ${{ env.RUST_TOOLCHAIN }}
-        override: true
     - name: Run cargo clippy
       uses: actions-rs/clippy-check@v1
       with:
@@ -68,20 +65,16 @@ jobs:
   cargo-fmt:
     name: Run cargo fmt
     runs-on: ubuntu-latest
-    env:
-      RUST_TOOLCHAIN: nightly
     steps:
     - uses: actions/checkout@v2
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
+        toolchain: stable
         components: rustfmt
-        toolchain: ${{ env.RUST_TOOLCHAIN }}
-        override: true
     - name: Run cargo fmt
       uses: actions-rs/cargo@v1
       with:
-        toolchain: ${{ env.RUST_TOOLCHAIN }}
         command: fmt
         args: --all -- --check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,31 @@ on:
     - release/*
 
 jobs:
+  cargo-test:
+    name: Run cargo test (${{ matrix.os }} / ${{ matrix.rust-version }} / ${{ matrix.runtime }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        rust-version: [1.52.0, beta, nightly]
+        runtime: [runtime-tokio, runtime-agnostic]
+        include:
+        - rust-version: nightly
+          continue-on-error: true
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: ${{ matrix.rust-version }}
+    - name: Run cargo test
+      continue-on-error: ${{ matrix.continue-on-error || false }}
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --no-default-features --features ${{ matrix.runtime }}
+
   # verify that Cargo.lock passes audit
   cargo-audit:
     name: Run cargo audit
@@ -78,55 +103,3 @@ jobs:
         toolchain: ${{ env.RUST_TOOLCHAIN }}
         command: fmt
         args: --all -- --check
-
-  # verify that tests pass
-  cargo-test-agnostic:
-    name: Run cargo test (runtime-agnostic)
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-        rust-version: [1.52.0, beta, nightly]
-        include:
-        - rust-version: nightly
-          continue-on-error: true
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: ${{ matrix.rust-version }}
-        override: yes
-    - name: Run cargo test
-      continue-on-error: ${{ matrix.continue-on-error || false }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --workspace --no-default-features --features runtime-agnostic
-
-  # verify that tests pass
-  cargo-test-tokio:
-    name: Run cargo test (runtime-tokio)
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-        rust-version: [1.52.0, beta, nightly]
-        include:
-        - rust-version: nightly
-          continue-on-error: true
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: ${{ matrix.rust-version }}
-        override: yes
-    - name: Run cargo test
-      continue-on-error: ${{ matrix.continue-on-error || false }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --workspace --no-default-features --features runtime-tokio

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,6 @@ jobs:
   # verify that Cargo.lock passes audit
   cargo-audit:
     name: Run cargo audit
-    needs: []
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -40,7 +39,6 @@ jobs:
   # verify that project passes clippy lints
   cargo-clippy:
     name: Run cargo clippy
-    needs: []
     runs-on: ubuntu-latest
     env:
       RUST_TOOLCHAIN: stable
@@ -62,7 +60,6 @@ jobs:
   # verify that code is formatted
   cargo-fmt:
     name: Run cargo fmt
-    needs: []
     runs-on: ubuntu-latest
     env:
       RUST_TOOLCHAIN: nightly
@@ -85,7 +82,6 @@ jobs:
   # verify that tests pass
   cargo-test-agnostic:
     name: Run cargo test (runtime-agnostic)
-    needs: []
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
@@ -112,7 +108,6 @@ jobs:
   # verify that tests pass
   cargo-test-tokio:
     name: Run cargo test (runtime-tokio)
-    needs: []
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]


### PR DESCRIPTION
### Changed

* Use consistent YAML array indentation.
* Trigger `main` workflow on `release/*` branches as well.
* Collapse the `cargo-test-`{`tokio`,`agnostic`} jobs into a single job and build matrix.
* Replace custom `cargo-audit` job with `actions-rs/audit-check`.
* Enforce stable `clippy` and `rustfmt`.
* Rename `main.yml` workflow to `ci.yml`.

### Removed

* Remove unnecessary empty `needs` keys.
* Remove redundant comments.

Follow-up to #309.