### PR TITLE
Miscellaneous codec improvements

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -25,7 +25,7 @@ pub enum ParseError {
     /// Failed to encode the response.
     Encode(IoError),
     /// Failed to parse headers.
-    Httparse(httparse::Error),
+    Headers(httparse::Error),
     /// Request lacks the required `Content-Length` header.
     MissingContentLength,
     /// The length value in the `Content-Length` header is invalid.
@@ -39,7 +39,7 @@ impl Display for ParseError {
         match *self {
             ParseError::Body(ref e) => write!(f, "unable to parse JSON body: {}", e),
             ParseError::Encode(ref e) => write!(f, "failed to encode response: {}", e),
-            ParseError::Httparse(ref e) => write!(f, "failed to parse headers: {}", e),
+            ParseError::Headers(ref e) => write!(f, "failed to parse headers: {}", e),
             ParseError::InvalidContentLength(ref e) => {
                 write!(f, "unable to parse content length: {}", e)
             }
@@ -223,7 +223,7 @@ impl<T: DeserializeOwned> Decoder for LanguageServerCodec<T> {
                 Ok(httparse::Status::Partial) => return Ok(None),
                 // An error occurred during parsing of the headers
                 Err(err) => {
-                    http_headers_err = Some(ParseError::Httparse(err));
+                    http_headers_err = Some(ParseError::Headers(err));
                 }
             }
         }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -96,7 +96,7 @@ impl<T> LanguageServerCodec<T> {
 impl<T> Default for LanguageServerCodec<T> {
     fn default() -> Self {
         LanguageServerCodec {
-            message_len: Option::<usize>::default(),
+            message_len: None,
             _marker: PhantomData,
         }
     }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -4,6 +4,7 @@ use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 use std::io::{Error as IoError, Write};
 use std::marker::PhantomData;
+use std::num::ParseIntError;
 use std::str::Utf8Error;
 
 use bytes::buf::BufMut;
@@ -28,7 +29,7 @@ pub enum ParseError {
     /// Request lacks the required `Content-Length` header.
     MissingContentLength,
     /// The length value in the `Content-Length` header is invalid.
-    InvalidContentLength(std::num::ParseIntError),
+    InvalidContentLength(ParseIntError),
     /// Request contains invalid UTF8.
     Utf8(Utf8Error),
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -87,18 +87,18 @@ pub struct LanguageServerCodec<T> {
     _marker: PhantomData<T>,
 }
 
-impl<T> LanguageServerCodec<T> {
-    pub fn reset(&mut self) {
-        *self = Self::default();
-    }
-}
-
 impl<T> Default for LanguageServerCodec<T> {
     fn default() -> Self {
         LanguageServerCodec {
             message_len: None,
             _marker: PhantomData,
         }
+    }
+}
+
+impl<T> LanguageServerCodec<T> {
+    fn reset(&mut self) {
+        self.message_len = None;
     }
 }
 


### PR DESCRIPTION
### Changed

* Refactor `LanguageServerCodec` for clarity and succinctness using recursion.
* Rename `ParseError::Httparse` to `Headers`, directly describing which part of the message failed to parse.

### Fixed

* Fix decoding chunked message bodies and add a unit test to enforce this invariant.
* Enforce correct `charset` values for `Content-Type` header, if specified, [as per the official spec](https://microsoft.github.io/language-server-protocol/specification#contentPart). In this case, that means requiring `utf-8` (or `utf8` for backwards compatibility).
* Add missing branch to `Error::source()` method implementation for `ParseError`.

Follow-up to #316.

Fixes #318.