### PR TITLE
Prepare release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.16.0] - 2022-03-10
+
+### Added
+
+* Support defining custom JSON-RPC requests on `LspService` (PR #313).
+* Add compatibility with WASM (PR #309).
+* Support alternative async runtimes other than `tokio` when enabling the
+  `runtime-agnostic` feature (PR #309).
+* Implement `Service<Request, Response = Option<Response>>` for `Client` (PR
+  #313).
+* Expose `concurrency_level` setting on `Server`, allowing adjustment from the
+  default value of 4.
+* Add `Request::build()` interface for creating custom requests.
+* Add convenient `From` implementations for `jsonrpc::Id`.
+* Add `.result()`/`.error()` and `.is_ok()`/`.is_error()` methods to
+  `jsonrpc::Response`.
+
+### Changed
+
+* `LspService` now implements `Service<Request, Response = Option<Response>>` .
+* `LspService::new()` now returns a `ClientSocket` instead of a `MessageStream`.
+* `Server::new()` now requires a third `ClientSocket` argument instead of using
+  `.interleave()`.
+* Rename `Client::send_custom_{request,notification}` to
+  `Client::send_{request,notification}`.
+* Rename `jsonrpc::Response::{ok, error}` to
+  `jsonrpc::Response::{from_ok, from_error}`.
+
+### Fixed
+
+* Close `Client` channel properly on `exit` notification (PR #309).
+* Fix `Server` occasionally stalling by processing client responses separately
+  from client-to-server requests (PR #313).
+* Return error code `-32600` (invalid request) if incoming data is valid JSON,
+  but isn't a JSON-RPC request or response (PR #313).
+
+### Removed
+
+* Remove `.interleave()` method from `Server` (PR #313).
+* Remove `jsonrpc::{ClientRequest, Incoming, Outgoing, ServerRequest}` (PR
+  #313).
+* Remove `MessageStream` (PR #313).
+
 ## [0.15.1] - 2022-02-14
 
 ### Fixed
@@ -444,7 +487,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * `textDocument/hover`
   * `textDocument/documentHighlight`
 
-[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.15.1...HEAD
+[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.15.0...v0.16.0
 [0.15.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.14.0...v0.14.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp"
-version = "0.15.1"
+version = "0.16.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 edition = "2018"
 description = "Language Server Protocol implementation based on Tower"
@@ -33,7 +33,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.17", optional = true }
 tokio-util = { version = "0.7", optional = true, features = ["codec"] }
-tower-lsp-macros = { version = "0.5", path = "./tower-lsp-macros" }
+tower-lsp-macros = { version = "0.6", path = "./tower-lsp-macros" }
 tower = { version = "0.4.12", default-features = false, features = ["util"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tower-lsp"
 version = "0.16.0"
-authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
+authors = ["Eyal Kalderon <ebkalderon@gmail.com>", "silvanshade <silvanshade@users.noreply.github.com>"]
 edition = "2018"
 description = "Language Server Protocol implementation based on Tower"
 license = "MIT OR Apache-2.0"

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021 Eyal Kalderon
+Copyright (c) 2022 Eyal Kalderon
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ async fn main() {
 }
 ```
 
+## Using runtimes other than tokio
+
+By default, `tower-lsp` is configured for use with `tokio`.
+
+Using `tower-lsp` with other runtimes requires disabling `default-features` and
+enabling the `runtime-agnostic` feature:
+
+```toml
+[dependencies.tower-lsp]
+version = "*"
+default-features = false
+features = ["runtime-agnostic"]
+```
+
 ## License
 
 `tower-lsp` is free and open source software distributed under the terms of

--- a/tower-lsp-macros/Cargo.toml
+++ b/tower-lsp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp-macros"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Internal procedural macros for tower-lsp"
 edition = "2018"


### PR DESCRIPTION
### Changed

* Bump `tower-lsp` version to 0.16.0.
* Bump `tower-lsp-macros` version to 0.6.0.
* Update `CHANGELOG.md`.
* Update `README.md` with instructions on usage with other async executors.
* Update `LICENSE-MIT` copyright year.
* Add @silvanshade as crate co-author.

New release with custom server request support should be coming very soon, @IWANABETHATGUY!

Closes #317.