### PR TITLE
Tweak lib.rs example program

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,11 +59,13 @@
 //! #   #[cfg(feature = "runtime-agnostic")]
 //! #   use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 //! #   use std::io::Cursor;
+//!     let stdin = tokio::io::stdin();
+//!     let stdout = tokio::io::stdout();
 //! #   let message = r#"{"jsonrpc":"2.0","method":"exit"}"#;
-//!     let (stdin, stdout) = (tokio::io::stdin(), tokio::io::stdout());
 //! #   let (stdin, stdout) = (Cursor::new(format!("Content-Length: {}\r\n\r\n{}", message.len(), message).into_bytes()), Cursor::new(Vec::new()));
 //! #   #[cfg(feature = "runtime-agnostic")]
 //! #   let (stdin, stdout) = (stdin.compat(), stdout.compat_write());
+//!
 //!     let (service, socket) = LspService::new(|client| Backend { client });
 //!     Server::new(stdin, stdout, socket).serve(service).await;
 //! }


### PR DESCRIPTION
### Changed

* Place the `stdin` and `stdout` variables on separate lines to make it (subjectively) easier to scan the bindings top-to-bottom.

This pull request does not require a new package release because it only affects documentation.