### PR TITLE
Remove unused Clone and Debug implementations

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -98,7 +98,6 @@ impl From<Utf8Error> for ParseError {
 }
 
 /// Encodes and decodes Language Server Protocol messages.
-#[derive(Clone, Debug)]
 pub struct LanguageServerCodec<T> {
     content_len: Option<usize>,
     _marker: PhantomData<T>,

--- a/src/jsonrpc/router.rs
+++ b/src/jsonrpc/router.rs
@@ -112,12 +112,6 @@ impl<P: FromParams, R: IntoResponse, E> MethodHandler<P, R, E> {
     }
 }
 
-impl<P, R, E> Debug for MethodHandler<P, R, E> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.debug_struct("MethodHandler").finish_non_exhaustive()
-    }
-}
-
 impl<P, R, E> Service<Request> for MethodHandler<P, R, E>
 where
     P: FromParams,


### PR DESCRIPTION
### Removed

* Remove unused `Clone` and `Debug` implementations from private types.

This pull request does not require a new package release because it only affects private types.