### PR TITLE
Fix broken links to Sink, Stream in docs.rs

### DIFF
--- a/src/service/client/socket.rs
+++ b/src/service/client/socket.rs
@@ -23,6 +23,9 @@ impl ClientSocket {
     /// Splits this `ClientSocket` into two halves capable of operating independently.
     ///
     /// The two halves returned implement the [`Stream`] and [`Sink`] traits, respectively.
+    ///
+    /// [`Stream`]: futures::Stream
+    /// [`Sink`]: futures::Sink
     pub fn split(self) -> (RequestStream, ResponseSink) {
         let ClientSocket { rx, pending, state } = self;
         let state_ = state.clone();


### PR DESCRIPTION
### Fixed

* Fix broken intra-doc links to `Sink`, `Stream` on `Loopback::split`.

This appears to work just fine when building documentation locally, but it breaks when deploying the docs to docs.rs, so we provide an explicit intra-doc link instead.