### PR TITLE
Update tungstenite dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+* Update `async-tungstenite` from `0.16` to `0.17`
+* Update `ws_stream_tungstenite` from `0.7` to `0.8`
+
 ## [0.17.0] - 2022-04-15
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,11 @@ tower-lsp-macros = { version = "0.6", path = "./tower-lsp-macros" }
 tower = { version = "0.4.12", default-features = false, features = ["util"] }
 
 [dev-dependencies]
-async-tungstenite = { version = "0.16", features = ["tokio-runtime"] }
+async-tungstenite = { version = "0.17", features = ["tokio-runtime"] }
 env_logger = "0.9"
 tokio = { version = "1.17", features = ["io-util", "io-std", "macros", "rt-multi-thread"] }
 tokio-util = { version = "0.7", features = ["compat"] }
-ws_stream_tungstenite = { version = "0.7", features = ["tokio_io"] }
+ws_stream_tungstenite = { version = "0.8", features = ["tokio_io"] }
 
 [workspace]
 members = [".", "./tower-lsp-macros"]


### PR DESCRIPTION
This PR updates the tungstenite dependencies and addresses https://github.com/ebkalderon/tower-lsp/pull/312.