### PR TITLE
implement getting a reference to the inner server from `LspService` and `Router`

### DIFF
--- a/src/jsonrpc/router.rs
+++ b/src/jsonrpc/router.rs
@@ -32,6 +32,11 @@ impl<S: Send + Sync + 'static, E> Router<S, E> {
         }
     }
 
+    /// Returns a reference to the inner server.
+    pub fn inner(&self) -> &S {
+        self.server.as_ref()
+    }
+
     /// Registers a new RPC method which constructs a response with the given `callback`.
     ///
     /// The `layer` argument can be used to inject middleware into the method handler, if desired.

--- a/src/service.rs
+++ b/src/service.rs
@@ -93,6 +93,11 @@ impl<S: LanguageServer> LspService<S> {
             socket,
         }
     }
+
+    /// Returns a reference to the inner server.
+    pub fn inner(&self) -> &S {
+        self.inner.inner()
+    }
 }
 
 impl<S: LanguageServer> Service<Request> for LspService<S> {
@@ -372,5 +377,35 @@ mod tests {
         let response = service.ready().await.unwrap().call(custom).await;
         let ok = Response::from_ok(1.into(), json!(123i32));
         assert_eq!(response, Ok(Some(ok)));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[allow(deprecated)]
+    async fn get_inner() {
+        let (service, _) = LspService::build(|_| Mock).finish();
+
+        service
+            .inner()
+            .initialize(InitializeParams {
+                process_id: None,
+                root_path: None,
+                root_uri: None,
+                initialization_options: None,
+                capabilities: ClientCapabilities {
+                    workspace: None,
+                    text_document: None,
+                    window: None,
+                    general: None,
+                    experimental: None,
+                    #[cfg(feature = "proposed")]
+                    offset_encoding: None,
+                },
+                trace: None,
+                workspace_folders: None,
+                client_info: None,
+                locale: None,
+            })
+            .await
+            .unwrap();
     }
 }


### PR DESCRIPTION
The utility for this is mostly in testing, wherein I want to be able to test inner state of the server contained within the `LspService`. This avoids the need to use the `custom_method` feature as a workaround, as the constraints on types returned and ceremony around sending/receiving jsonrpc messages is too much hassle imo.

Have tested this locally with my own `LanguageServer` impl and all seemed :ok: so far :slightly_smiling_face: 