### PR TITLE
Add note about WebAssembly example

### DIFF
--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -1,0 +1,3 @@
+# WebAssembly tower-lsp example
+
+See [tower-lsp-web-demo](https://github.com/silvanshade/tower-lsp-web-demo) for a complete example that uses `tower-lsp` to build a language server which compiles to Wasm and runs in the browser.


### PR DESCRIPTION
@ebkalderon I thought it might be a good idea to include a reference to a complete example that uses `tower-lsp` for a wasm target given the discussion in https://github.com/ebkalderon/tower-lsp/issues/341.

I considered including the full project in the examples directory but it's a complex project and doesn't play well with the editor in a subdirectory so it seemed better to just link to a separate repo. Let me know if you think that seems reasonable.