### PR TITLE
Refactor ::serve to multiple variants

### DIFF
--- a/examples/custom_notification.rs
+++ b/examples/custom_notification.rs
@@ -85,5 +85,7 @@ async fn main() {
     let (stdin, stdout) = (stdin.compat(), stdout.compat_write());
 
     let (service, socket) = LspService::new(|client| Backend { client });
-    Server::new(stdin, stdout, socket).serve(service).await;
+    Server::new(socket)
+        .serve_messages_with_headers(service, stdin, stdout)
+        .await;
 }

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -127,5 +127,7 @@ async fn main() {
     let (stdin, stdout) = (stdin.compat(), stdout.compat_write());
 
     let (service, socket) = LspService::new(|client| Backend { client });
-    Server::new(stdin, stdout, socket).serve(service).await;
+    Server::new(socket)
+        .serve_messages_with_headers(service, stdin, stdout)
+        .await;
 }

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -151,5 +151,7 @@ async fn main() {
     let (read, write) = (read.compat(), write.compat_write());
 
     let (service, socket) = LspService::new(|client| Backend { client });
-    Server::new(read, write, socket).serve(service).await;
+    Server::new(socket)
+        .serve_messages_with_headers(service, read, write)
+        .await;
 }

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -132,5 +132,7 @@ async fn main() {
     let (read, write) = (read.compat(), write.compat_write());
 
     let (service, socket) = LspService::new(|client| Backend { client });
-    Server::new(read, write, socket).serve(service).await;
+    Server::new(socket)
+        .serve_messages_with_headers(service, read, write)
+        .await;
 }

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -349,10 +349,9 @@ enum ResponseKind {
 }
 
 /// An incoming or outgoing JSON-RPC message.
-#[derive(Deserialize, Serialize)]
-#[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(untagged)]
-pub(crate) enum Message {
+pub enum Message {
     /// A response message.
     Response(Response),
     /// A request or notification message.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@
 //! #   let (stdin, stdout) = (stdin.compat(), stdout.compat_write());
 //!
 //!     let (service, socket) = LspService::new(|client| Backend { client });
-//!     Server::new(stdin, stdout, socket).serve(service).await;
+//!     Server::new(socket).serve(service, stdin, stdout).await;
 //! }
 //! ```
 


### PR DESCRIPTION
@ebkalderon This PR refactors the `Server::serve` function into multiple variants, one of which allows for passing a `I: Stream<Item = Message>` and `O: Sink<Message>` rather than just `I: AsyncRead` and `O: AsyncWrite`.

This change was motivated by my experience working with tower-lsp for a wasm target in the [tower-lsp-web-demo](https://github.com/silvanshade/tower-lsp-web-demo) project and is also relevant to #341.

Since in that case no data was actually be processed over stdin/stdout, there was no real justification to use byte-based framed IO with messages delimited by `Content-Length` headers, and a significant amount of code was needed just to convert from the underlying web `ReadableStream` and `WritableStream` based data structures used internally for server client communication into something that could interface with `tower-lsp`.

With this PR, instead I could simply use `Server::serve_messages` from `tower-lsp` for that project.