### PR TITLE
Update several dependencies, loosen patch requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,23 +26,23 @@ auto_impl = "1.0"
 bytes = "1.0"
 dashmap = "5.1"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
-httparse = "1.3.5"
+httparse = "1.8"
 lsp-types = "0.93"
-memchr = "2.4.1"
+memchr = "2.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.17", optional = true }
 tokio-util = { version = "0.7", optional = true, features = ["codec"] }
 tower-lsp-macros = { version = "0.6", path = "./tower-lsp-macros" }
-tower = { version = "0.4.12", default-features = false, features = ["util"] }
-tracing = "0.1.34"
+tower = { version = "0.4", default-features = false, features = ["util"] }
+tracing = "0.1"
 
 [dev-dependencies]
-async-tungstenite = { version = "0.17", features = ["tokio-runtime"] }
-tracing-subscriber = "0.3.11"
+async-tungstenite = { version = "0.18", features = ["tokio-runtime"] }
+tracing-subscriber = "0.3"
 tokio = { version = "1.17", features = ["io-util", "io-std", "macros", "rt-multi-thread"] }
 tokio-util = { version = "0.7", features = ["compat"] }
-ws_stream_tungstenite = { version = "0.8", features = ["tokio_io"] }
+ws_stream_tungstenite = { version = "0.9", features = ["tokio_io"] }
 
 [workspace]
 members = [".", "./tower-lsp-macros"]

--- a/src/service/pending.rs
+++ b/src/service/pending.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use dashmap::{mapref::entry::Entry, DashMap};
 use futures::future::{self, Either};
-use tracing::{info, debug};
+use tracing::{debug, info};
 
 use super::ExitedError;
 use crate::jsonrpc::{Error, Id, Response};


### PR DESCRIPTION
### Changed

* Update `httparse` dependency from 1.3.5 to 1.8  (also relaxing semver requirement).
* Update `memchr` dependency from 2.4.1 to 2.5 (also relaxing semver requirement).
* Relax version requirement for `tower` dependency from 0.4.12 to 0.4.
* Relax version requirement for `tracing` dependency from 0.1.34 to 0.1.
* Update `async-tungstenite` dev dependency from 0.17 to 0.18.
* Relax version requirement for `tracing-subscriber` dev dependency from 0.3.11 to 0.3.
* Update `ws_stream_tungstenite` dev dependency from 0.8 to 0.9.

Closes #357.
Closes #360.
Relates to #359, #362.