### PR TITLE
Complete release 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-* Update `async-tungstenite` from `0.16` to `0.17`
-* Update `ws_stream_tungstenite` from `0.7` to `0.8`
-* Switching from `log` facade to `tracing`.
+## [0.18.0] - 2023-01-14
+
+### Changed
+
+* Switch from `log` facade to `tracing` (PR #332).
+* Change `$/cancelRequest` log message from `warn` to `debug` (PR #353).
+* Update `auto_impl` from `0.5` to `1.0` (PR #343).
+* Update `httparse` from `1.3.5` to `1.8` (PR #363)
+* Update `memchr` from `2.4.1` to `2.5` (PR #363).
+* Relax `tower` version requirement from `0.3.11` to `0.3` (PR #363).
+* Update dev-dependency `async-tungstenite` from `0.16` to `0.18` (PR #363).
+* Update dev-dependency `ws_stream_tungstenite` from `0.7` to `0.9` (PR #363).
+
+### Fixed
+
+* Improve client connection behavior in `tcp` example (PR #336).
+* Tweak grammar in `initialized` and `textDocument/codeAction` doc comments (PR #361).
 
 ## [0.17.0] - 2022-04-15
 
@@ -501,7 +515,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * `textDocument/hover`
   * `textDocument/documentHighlight`
 
-[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/ebkalderon/tower-lsp/compare/v0.15.0...v0.15.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 edition = "2018"
 description = "Language Server Protocol implementation based on Tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.17", optional = true }
 tokio-util = { version = "0.7", optional = true, features = ["codec"] }
-tower-lsp-macros = { version = "0.6", path = "./tower-lsp-macros" }
+tower-lsp-macros = { version = "0.7", path = "./tower-lsp-macros" }
 tower = { version = "0.4", default-features = false, features = ["util"] }
 tracing = "0.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,8 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
+//! #   tracing_subscriber::fmt().init();
+//! #
 //! #   #[cfg(feature = "runtime-agnostic")]
 //! #   use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 //! #   use std::io::Cursor;

--- a/tower-lsp-macros/Cargo.toml
+++ b/tower-lsp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp-macros"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Internal procedural macros for tower-lsp"
 edition = "2018"

--- a/tower-lsp-macros/src/lib.rs
+++ b/tower-lsp-macros/src/lib.rs
@@ -146,7 +146,6 @@ fn gen_server_router(trait_name: &syn::Ident, methods: &[MethodCall]) -> proc_ma
             use std::sync::Arc;
             use std::future::{Future, Ready};
 
-            use tracing::info;
             use lsp_types::*;
             use lsp_types::notification::*;
             use lsp_types::request::*;


### PR DESCRIPTION
### Changed

* Update `CHANGELOG.md`.
* Bump `tower-lsp` version to 0.18.0.
* Bump `tower-lsp-macros` version to 0.7.0.
* Follow-up changes to #332.