### PR TITLE
Optimize JSON-RPC types

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -151,7 +151,6 @@ impl<T: Serialize> Encoder<T> for LanguageServerCodec<T> {
     }
 }
 
-#[inline]
 fn number_of_digits(mut n: usize) -> usize {
     let mut num_digits = 0;
 

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -387,7 +387,7 @@ impl Serialize for Version {
 ///
 /// See [here](https://microsoft.github.io/language-server-protocol/specification#initialize)
 /// for reference.
-pub(crate) fn not_initialized_error() -> Error {
+pub(crate) const fn not_initialized_error() -> Error {
     Error {
         code: ErrorCode::ServerError(-32002),
         message: Cow::Borrowed("Server not initialized"),

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -390,7 +390,7 @@ impl Serialize for Version {
 pub(crate) fn not_initialized_error() -> Error {
     Error {
         code: ErrorCode::ServerError(-32002),
-        message: "Server not initialized".to_string(),
+        message: Cow::Borrowed("Server not initialized"),
         data: None,
     }
 }

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -149,25 +149,21 @@ impl Request {
     }
 
     /// Returns the name of the method to be invoked.
-    #[inline]
     pub fn method(&self) -> &str {
         self.method.as_ref()
     }
 
     /// Returns the unique ID of this request, if present.
-    #[inline]
     pub fn id(&self) -> Option<&Id> {
         self.id.as_ref()
     }
 
     /// Returns the `params` field, if present.
-    #[inline]
     pub fn params(&self) -> Option<&Value> {
         self.params.as_ref()
     }
 
     /// Splits this request into the method name, request ID, and the `params` field, if present.
-    #[inline]
     pub fn into_parts(self) -> (Cow<'static, str>, Option<Id>, Option<Value>) {
         (self.method, self.id, self.params)
     }
@@ -250,7 +246,6 @@ pub struct Response {
 
 impl Response {
     /// Creates a new successful response from a request ID and `Error` object.
-    #[inline]
     pub const fn from_ok(id: Id, result: Value) -> Self {
         Response {
             jsonrpc: Version,
@@ -260,7 +255,6 @@ impl Response {
     }
 
     /// Creates a new error response from a request ID and `Error` object.
-    #[inline]
     pub const fn from_error(id: Id, error: Error) -> Self {
         Response {
             jsonrpc: Version,
@@ -287,13 +281,11 @@ impl Response {
     }
 
     /// Returns `true` if the response indicates success.
-    #[inline]
     pub const fn is_ok(&self) -> bool {
         matches!(self.kind, ResponseKind::Ok { .. })
     }
 
     /// Returns `true` if the response indicates failure.
-    #[inline]
     pub const fn is_error(&self) -> bool {
         !self.is_ok()
     }
@@ -301,7 +293,6 @@ impl Response {
     /// Returns the `result` value, if it exists.
     ///
     /// This member only exists if the response indicates success.
-    #[inline]
     pub const fn result(&self) -> Option<&Value> {
         match &self.kind {
             ResponseKind::Ok { result } => Some(result),
@@ -312,7 +303,6 @@ impl Response {
     /// Returns the `error` value, if it exists.
     ///
     /// This member only exists if the response indicates failure.
-    #[inline]
     pub const fn error(&self) -> Option<&Error> {
         match &self.kind {
             ResponseKind::Err { error } => Some(error),
@@ -321,7 +311,6 @@ impl Response {
     }
 
     /// Returns the corresponding request ID, if known.
-    #[inline]
     pub const fn id(&self) -> &Id {
         &self.id
     }

--- a/src/jsonrpc/error.rs
+++ b/src/jsonrpc/error.rs
@@ -1,5 +1,6 @@
 //! Error types defined by the JSON-RPC specification.
 
+use std::borrow::Cow;
 use std::fmt::{self, Display, Formatter};
 
 use serde::de::Deserializer;
@@ -117,7 +118,7 @@ pub struct Error {
     /// A number indicating the error type that occurred.
     pub code: ErrorCode,
     /// A short description of the error.
-    pub message: String,
+    pub message: Cow<'static, str>,
     /// Additional information about the error, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Value>,
@@ -129,7 +130,7 @@ impl Error {
     pub fn new(code: ErrorCode) -> Self {
         Error {
             code,
-            message: code.description().to_string(),
+            message: Cow::Borrowed(code.description()),
             data: None,
         }
     }
@@ -156,7 +157,7 @@ impl Error {
     #[inline]
     pub fn invalid_params<M>(message: M) -> Self
     where
-        M: Into<String>,
+        M: Into<Cow<'static, str>>,
     {
         Error {
             code: ErrorCode::InvalidParams,

--- a/src/jsonrpc/error.rs
+++ b/src/jsonrpc/error.rs
@@ -40,7 +40,6 @@ pub enum ErrorCode {
 
 impl ErrorCode {
     /// Returns the integer error code value.
-    #[inline]
     pub const fn code(&self) -> i64 {
         match *self {
             ErrorCode::ParseError => -32700,
@@ -55,7 +54,6 @@ impl ErrorCode {
     }
 
     /// Returns a human-readable description of the error.
-    #[inline]
     pub const fn description(&self) -> &'static str {
         match *self {
             ErrorCode::ParseError => "Parse error",
@@ -71,7 +69,6 @@ impl ErrorCode {
 }
 
 impl From<i64> for ErrorCode {
-    #[inline]
     fn from(code: i64) -> Self {
         match code {
             -32700 => ErrorCode::ParseError,
@@ -126,7 +123,6 @@ pub struct Error {
 
 impl Error {
     /// Creates a new error from the given `ErrorCode`.
-    #[inline]
     pub const fn new(code: ErrorCode) -> Self {
         Error {
             code,
@@ -136,25 +132,21 @@ impl Error {
     }
 
     /// Creates a new parse error (`-32700`).
-    #[inline]
     pub const fn parse_error() -> Self {
         Error::new(ErrorCode::ParseError)
     }
 
     /// Creates a new "invalid request" error (`-32600`).
-    #[inline]
     pub const fn invalid_request() -> Self {
         Error::new(ErrorCode::InvalidRequest)
     }
 
     /// Creates a new "method not found" error (`-32601`).
-    #[inline]
     pub const fn method_not_found() -> Self {
         Error::new(ErrorCode::MethodNotFound)
     }
 
     /// Creates a new "invalid params" error (`-32602`).
-    #[inline]
     pub fn invalid_params<M>(message: M) -> Self
     where
         M: Into<Cow<'static, str>>,
@@ -167,7 +159,6 @@ impl Error {
     }
 
     /// Creates a new internal error (`-32603`).
-    #[inline]
     pub const fn internal_error() -> Self {
         Error::new(ErrorCode::InternalError)
     }
@@ -177,7 +168,6 @@ impl Error {
     /// # Compatibility
     ///
     /// This error code is defined by the Language Server Protocol.
-    #[inline]
     pub const fn request_cancelled() -> Self {
         Error::new(ErrorCode::RequestCancelled)
     }
@@ -187,7 +177,6 @@ impl Error {
     /// # Compatibility
     ///
     /// This error code is defined by the Language Server Protocol.
-    #[inline]
     pub const fn content_modified() -> Self {
         Error::new(ErrorCode::ContentModified)
     }

--- a/src/jsonrpc/error.rs
+++ b/src/jsonrpc/error.rs
@@ -41,7 +41,7 @@ pub enum ErrorCode {
 impl ErrorCode {
     /// Returns the integer error code value.
     #[inline]
-    pub fn code(&self) -> i64 {
+    pub const fn code(&self) -> i64 {
         match *self {
             ErrorCode::ParseError => -32700,
             ErrorCode::InvalidRequest => -32600,
@@ -56,7 +56,7 @@ impl ErrorCode {
 
     /// Returns a human-readable description of the error.
     #[inline]
-    pub fn description(&self) -> &'static str {
+    pub const fn description(&self) -> &'static str {
         match *self {
             ErrorCode::ParseError => "Parse error",
             ErrorCode::InvalidRequest => "Invalid request",
@@ -127,7 +127,7 @@ pub struct Error {
 impl Error {
     /// Creates a new error from the given `ErrorCode`.
     #[inline]
-    pub fn new(code: ErrorCode) -> Self {
+    pub const fn new(code: ErrorCode) -> Self {
         Error {
             code,
             message: Cow::Borrowed(code.description()),
@@ -137,19 +137,19 @@ impl Error {
 
     /// Creates a new parse error (`-32700`).
     #[inline]
-    pub fn parse_error() -> Self {
+    pub const fn parse_error() -> Self {
         Error::new(ErrorCode::ParseError)
     }
 
     /// Creates a new "invalid request" error (`-32600`).
     #[inline]
-    pub fn invalid_request() -> Self {
+    pub const fn invalid_request() -> Self {
         Error::new(ErrorCode::InvalidRequest)
     }
 
     /// Creates a new "method not found" error (`-32601`).
     #[inline]
-    pub fn method_not_found() -> Self {
+    pub const fn method_not_found() -> Self {
         Error::new(ErrorCode::MethodNotFound)
     }
 
@@ -168,7 +168,7 @@ impl Error {
 
     /// Creates a new internal error (`-32603`).
     #[inline]
-    pub fn internal_error() -> Self {
+    pub const fn internal_error() -> Self {
         Error::new(ErrorCode::InternalError)
     }
 
@@ -178,7 +178,7 @@ impl Error {
     ///
     /// This error code is defined by the Language Server Protocol.
     #[inline]
-    pub fn request_cancelled() -> Self {
+    pub const fn request_cancelled() -> Self {
         Error::new(ErrorCode::RequestCancelled)
     }
 
@@ -188,7 +188,7 @@ impl Error {
     ///
     /// This error code is defined by the Language Server Protocol.
     #[inline]
-    pub fn content_modified() -> Self {
+    pub const fn content_modified() -> Self {
         Error::new(ErrorCode::ContentModified)
     }
 }

--- a/src/jsonrpc/router.rs
+++ b/src/jsonrpc/router.rs
@@ -257,7 +257,7 @@ impl<R: Serialize + Send + 'static> IntoResponse for Result<R, Error> {
             let result = self.and_then(|r| {
                 serde_json::to_value(r).map_err(|e| Error {
                     code: ErrorCode::InternalError,
-                    message: e.to_string(),
+                    message: e.to_string().into(),
                     data: None,
                 })
             });

--- a/src/service/client.rs
+++ b/src/service/client.rs
@@ -478,7 +478,7 @@ impl Client {
         result.and_then(|v| {
             serde_json::from_value(v).map_err(|e| Error {
                 code: ErrorCode::ParseError,
-                message: e.to_string(),
+                message: e.to_string().into(),
                 data: None,
             })
         })

--- a/src/service/client/pending.rs
+++ b/src/service/client/pending.rs
@@ -14,7 +14,6 @@ pub struct Pending(DashMap<Id, Vec<oneshot::Sender<Response>>>);
 
 impl Pending {
     /// Creates a new pending client requests map.
-    #[inline]
     pub fn new() -> Self {
         Pending(DashMap::new())
     }

--- a/src/service/client/socket.rs
+++ b/src/service/client/socket.rs
@@ -49,14 +49,12 @@ impl Stream for ClientSocket {
         }
     }
 
-    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.rx.size_hint()
     }
 }
 
 impl FusedStream for ClientSocket {
-    #[inline]
     fn is_terminated(&self) -> bool {
         self.rx.is_terminated()
     }
@@ -107,14 +105,12 @@ impl Stream for RequestStream {
         }
     }
 
-    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.rx.size_hint()
     }
 }
 
 impl FusedStream for RequestStream {
-    #[inline]
     fn is_terminated(&self) -> bool {
         self.rx.is_terminated()
     }

--- a/src/service/layers.rs
+++ b/src/service/layers.rs
@@ -26,7 +26,7 @@ pub struct Initialize {
 }
 
 impl Initialize {
-    pub const fn new(state: Arc<ServerState>, pending: Arc<Pending>) -> Self {
+    pub fn new(state: Arc<ServerState>, pending: Arc<Pending>) -> Self {
         Initialize { state, pending }
     }
 }
@@ -95,7 +95,7 @@ pub struct Shutdown {
 }
 
 impl Shutdown {
-    pub const fn new(state: Arc<ServerState>, pending: Arc<Pending>) -> Self {
+    pub fn new(state: Arc<ServerState>, pending: Arc<Pending>) -> Self {
         Shutdown { state, pending }
     }
 }
@@ -157,7 +157,7 @@ pub struct Exit {
 }
 
 impl Exit {
-    pub const fn new(state: Arc<ServerState>, pending: Arc<Pending>, client: Client) -> Self {
+    pub fn new(state: Arc<ServerState>, pending: Arc<Pending>, client: Client) -> Self {
         Exit {
             state,
             pending,
@@ -216,7 +216,7 @@ pub struct Normal {
 }
 
 impl Normal {
-    pub const fn new(state: Arc<ServerState>, pending: Arc<Pending>) -> Self {
+    pub fn new(state: Arc<ServerState>, pending: Arc<Pending>) -> Self {
         Normal { state, pending }
     }
 }
@@ -273,7 +273,7 @@ struct Cancellable<S> {
 }
 
 impl<S> Cancellable<S> {
-    const fn new(inner: S, pending: Arc<Pending>) -> Self {
+    fn new(inner: S, pending: Arc<Pending>) -> Self {
         Cancellable { inner, pending }
     }
 }

--- a/src/service/layers.rs
+++ b/src/service/layers.rs
@@ -26,7 +26,6 @@ pub struct Initialize {
 }
 
 impl Initialize {
-    #[inline]
     pub const fn new(state: Arc<ServerState>, pending: Arc<Pending>) -> Self {
         Initialize { state, pending }
     }
@@ -96,7 +95,6 @@ pub struct Shutdown {
 }
 
 impl Shutdown {
-    #[inline]
     pub const fn new(state: Arc<ServerState>, pending: Arc<Pending>) -> Self {
         Shutdown { state, pending }
     }
@@ -159,7 +157,6 @@ pub struct Exit {
 }
 
 impl Exit {
-    #[inline]
     pub const fn new(state: Arc<ServerState>, pending: Arc<Pending>, client: Client) -> Self {
         Exit {
             state,
@@ -219,7 +216,6 @@ pub struct Normal {
 }
 
 impl Normal {
-    #[inline]
     pub const fn new(state: Arc<ServerState>, pending: Arc<Pending>) -> Self {
         Normal { state, pending }
     }
@@ -277,7 +273,6 @@ struct Cancellable<S> {
 }
 
 impl<S> Cancellable<S> {
-    #[inline]
     const fn new(inner: S, pending: Arc<Pending>) -> Self {
         Cancellable { inner, pending }
     }

--- a/src/service/pending.rs
+++ b/src/service/pending.rs
@@ -16,7 +16,6 @@ pub struct Pending(Arc<DashMap<Id, future::AbortHandle>>);
 
 impl Pending {
     /// Creates a new pending server requests map.
-    #[inline]
     pub fn new() -> Self {
         Pending(Arc::new(DashMap::new()))
     }
@@ -70,7 +69,6 @@ impl Pending {
     }
 
     /// Cancels all pending request handlers, if any.
-    #[inline]
     pub fn cancel_all(&self) {
         self.0.retain(|_, handle| {
             handle.abort();

--- a/src/service/state.rs
+++ b/src/service/state.rs
@@ -23,17 +23,14 @@ pub enum State {
 pub struct ServerState(AtomicU8);
 
 impl ServerState {
-    #[inline]
     pub const fn new() -> Self {
         ServerState(AtomicU8::new(State::Uninitialized as u8))
     }
 
-    #[inline]
     pub fn set(&self, state: State) {
         self.0.store(state as u8, Ordering::SeqCst);
     }
 
-    #[inline]
     pub fn get(&self) -> State {
         match self.0.load(Ordering::SeqCst) {
             0 => State::Uninitialized,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -173,7 +173,6 @@ fn display_sources(error: &dyn std::error::Error) -> String {
 }
 
 #[cfg(feature = "runtime-tokio")]
-#[inline]
 fn to_jsonrpc_error(err: ParseError) -> Error {
     match err {
         ParseError::Body(err) if err.is_data() => Error::invalid_request(),
@@ -182,7 +181,6 @@ fn to_jsonrpc_error(err: ParseError) -> Error {
 }
 
 #[cfg(feature = "runtime-agnostic")]
-#[inline]
 fn to_jsonrpc_error(err: impl std::error::Error) -> Error {
     match err.source().and_then(|e| e.downcast_ref()) {
         Some(ParseError::Body(err)) if err.is_data() => Error::invalid_request(),
@@ -231,7 +229,6 @@ mod tests {
         type RequestStream = stream::Iter<std::vec::IntoIter<Request>>;
         type ResponseSink = sink::Drain<Response>;
 
-        #[inline]
         fn split(self) -> (Self::RequestStream, Self::ResponseSink) {
             (stream::iter(self.0), sink::drain())
         }


### PR DESCRIPTION
### Changed

* Change `jsonrpc::Error::message` field to `Cow<'static, str>`.
* Constify more methods on `jsonrpc::Error`.
* Remove unnecessary `#[inline]` attributes.
* Use regular `fn` constructors in `layers.rs`.