### PR TITLE
Clean up JSON-RPC types and deserialization code

### DIFF
--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -79,17 +79,6 @@ impl From<NumberOrString> for Id {
     }
 }
 
-/// An incoming or outgoing JSON-RPC message.
-#[derive(Deserialize, Serialize)]
-#[cfg_attr(test, derive(Debug, PartialEq))]
-#[serde(untagged)]
-pub(crate) enum Message {
-    /// A response message.
-    Response(Response),
-    /// A request or notification message.
-    Request(Request),
-}
-
 #[derive(Clone, Debug, PartialEq)]
 struct Version;
 
@@ -117,6 +106,17 @@ impl Serialize for Version {
     {
         serializer.serialize_str("2.0")
     }
+}
+
+/// An incoming or outgoing JSON-RPC message.
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[serde(untagged)]
+pub(crate) enum Message {
+    /// A response message.
+    Response(Response),
+    /// A request or notification message.
+    Request(Request),
 }
 
 #[cfg(test)]

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -1,9 +1,9 @@
 //! A subset of JSON-RPC types used by the Language Server Protocol.
 
 pub use self::error::{Error, ErrorCode, Result};
-pub use self::router::{FromParams, IntoResponse, Method};
-
+pub use self::request::{Request, RequestBuilder};
 pub(crate) use self::router::Router;
+pub use self::router::{FromParams, IntoResponse, Method};
 
 use std::borrow::Cow;
 use std::fmt::{self, Debug, Display, Formatter};
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 mod error;
+mod request;
 mod router;
 
 /// A unique ID used to correlate requests and responses together.
@@ -72,160 +73,6 @@ impl From<NumberOrString> for Id {
         match num_or_str {
             NumberOrString::Number(num) => Id::Number(num as i64),
             NumberOrString::String(s) => Id::String(s),
-        }
-    }
-}
-
-fn deserialize_some<'de, T, D>(deserializer: D) -> std::result::Result<Option<T>, D::Error>
-where
-    T: Deserialize<'de>,
-    D: Deserializer<'de>,
-{
-    T::deserialize(deserializer).map(Some)
-}
-
-/// A JSON-RPC request or notification.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub struct Request {
-    jsonrpc: Version,
-    #[serde(default)]
-    method: Cow<'static, str>,
-    #[serde(default, deserialize_with = "deserialize_some")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    params: Option<Value>,
-    #[serde(default, deserialize_with = "deserialize_some")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    id: Option<Id>,
-}
-
-impl Request {
-    /// Starts building a JSON-RPC method call.
-    ///
-    /// Returns a `RequestBuilder`, which allows setting the `params` field or adding a request ID.
-    pub fn build<M>(method: M) -> RequestBuilder
-    where
-        M: Into<Cow<'static, str>>,
-    {
-        RequestBuilder {
-            method: method.into(),
-            params: None,
-            id: None,
-        }
-    }
-
-    /// Constructs a JSON-RPC request from its corresponding LSP type.
-    pub(crate) fn from_request<R>(id: Id, params: R::Params) -> Self
-    where
-        R: lsp_types::request::Request,
-    {
-        // Since `R::Params` come from the `lsp-types` crate and validity is enforced via the
-        // `Request` trait, the `unwrap()` call below should never fail.
-        Request {
-            jsonrpc: Version,
-            method: R::METHOD.into(),
-            params: Some(serde_json::to_value(params).unwrap()),
-            id: Some(id),
-        }
-    }
-
-    /// Constructs a JSON-RPC notification from its corresponding LSP type.
-    pub(crate) fn from_notification<N>(params: N::Params) -> Self
-    where
-        N: lsp_types::notification::Notification,
-    {
-        // Since `N::Params` comes from the `lsp-types` crate and validity is enforced via the
-        // `Notification` trait, the `unwrap()` call below should never fail.
-        Request {
-            jsonrpc: Version,
-            method: N::METHOD.into(),
-            params: Some(serde_json::to_value(params).unwrap()),
-            id: None,
-        }
-    }
-
-    /// Returns the name of the method to be invoked.
-    pub fn method(&self) -> &str {
-        self.method.as_ref()
-    }
-
-    /// Returns the unique ID of this request, if present.
-    pub fn id(&self) -> Option<&Id> {
-        self.id.as_ref()
-    }
-
-    /// Returns the `params` field, if present.
-    pub fn params(&self) -> Option<&Value> {
-        self.params.as_ref()
-    }
-
-    /// Splits this request into the method name, request ID, and the `params` field, if present.
-    pub fn into_parts(self) -> (Cow<'static, str>, Option<Id>, Option<Value>) {
-        (self.method, self.id, self.params)
-    }
-}
-
-impl Display for Request {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let mut w = WriterFormatter { inner: f };
-        serde_json::to_writer(&mut w, self).map_err(|_| fmt::Error)
-    }
-}
-
-struct WriterFormatter<'a, 'b: 'a> {
-    inner: &'a mut Formatter<'b>,
-}
-
-impl<'a, 'b> std::io::Write for WriterFormatter<'a, 'b> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        fn io_error<E>(_: E) -> std::io::Error {
-            // Error value does not matter because fmt::Display impl below just
-            // maps it to fmt::Error
-            std::io::Error::new(std::io::ErrorKind::Other, "fmt error")
-        }
-        let s = std::str::from_utf8(buf).map_err(io_error)?;
-        self.inner.write_str(s).map_err(io_error)?;
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
-/// A builder to construct the properties of a `Request`.
-///
-/// To construct a `RequestBuilder`, refer to [`Request::build`].
-#[derive(Debug)]
-pub struct RequestBuilder {
-    method: Cow<'static, str>,
-    params: Option<Value>,
-    id: Option<Id>,
-}
-
-impl RequestBuilder {
-    /// Sets the `id` member of the request to the given value.
-    ///
-    /// If this method is not called, the resulting `Request` will be assumed to be a notification.
-    pub fn id<I: Into<Id>>(mut self, id: I) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    /// Sets the `params` member of the request to the given value.
-    ///
-    /// This member is omitted from the request by default.
-    pub fn params<V: Into<Value>>(mut self, params: V) -> Self {
-        self.params = Some(params.into());
-        self
-    }
-
-    /// Constructs the JSON-RPC request and returns it.
-    pub fn finish(self) -> Request {
-        Request {
-            jsonrpc: Version,
-            method: self.method,
-            params: self.params,
-            id: self.id,
         }
     }
 }

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -1,6 +1,6 @@
 //! A subset of JSON-RPC types used by the Language Server Protocol.
 
-pub use self::error::{Error, ErrorCode};
+pub use self::error::{Error, ErrorCode, Result};
 pub use self::router::{FromParams, IntoResponse, Method};
 
 pub(crate) use self::router::Router;
@@ -16,11 +16,6 @@ use serde_json::Value;
 
 mod error;
 mod router;
-
-/// A specialized [`Result`] error type for JSON-RPC handlers.
-///
-/// [`Result`]: enum@std::result::Result
-pub type Result<T> = std::result::Result<T, Error>;
 
 /// A unique ID used to correlate requests and responses together.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -1,5 +1,6 @@
 //! A subset of JSON-RPC types used by the Language Server Protocol.
 
+pub(crate) use self::error::not_initialized_error;
 pub use self::error::{Error, ErrorCode, Result};
 pub use self::request::{Request, RequestBuilder};
 pub use self::response::Response;
@@ -115,18 +116,6 @@ impl Serialize for Version {
         S: Serializer,
     {
         serializer.serialize_str("2.0")
-    }
-}
-
-/// Error response returned for every request received before the server is initialized.
-///
-/// See [here](https://microsoft.github.io/language-server-protocol/specification#initialize)
-/// for reference.
-pub(crate) const fn not_initialized_error() -> Error {
-    Error {
-        code: ErrorCode::ServerError(-32002),
-        message: Cow::Borrowed("Server not initialized"),
-        data: None,
     }
 }
 

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -348,8 +348,8 @@ pub(crate) enum Message {
     Request(Request),
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) struct Version;
+#[derive(Clone, Debug, PartialEq)]
+struct Version;
 
 impl<'de> Deserialize<'de> for Version {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -356,7 +356,12 @@ impl<'de> Deserialize<'de> for Version {
     where
         D: Deserializer<'de>,
     {
-        match Cow::<'de, str>::deserialize(deserializer)?.as_ref() {
+        #[derive(Deserialize)]
+        struct Inner<'a>(#[serde(borrow)] Cow<'a, str>);
+
+        let Inner(ver) = Inner::deserialize(deserializer)?;
+
+        match ver.as_ref() {
             "2.0" => Ok(Version),
             _ => Err(de::Error::custom("expected JSON-RPC version \"2.0\"")),
         }
@@ -368,7 +373,7 @@ impl Serialize for Version {
     where
         S: Serializer,
     {
-        "2.0".serialize(serializer)
+        serializer.serialize_str("2.0")
     }
 }
 

--- a/src/jsonrpc/error.rs
+++ b/src/jsonrpc/error.rs
@@ -8,6 +8,11 @@ use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// A specialized [`Result`] error type for JSON-RPC handlers.
+///
+/// [`Result`]: enum@std::result::Result
+pub type Result<T> = std::result::Result<T, Error>;
+
 /// A list of numeric error codes used in JSON-RPC responses.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ErrorCode {

--- a/src/jsonrpc/error.rs
+++ b/src/jsonrpc/error.rs
@@ -87,9 +87,9 @@ impl From<i64> for ErrorCode {
     }
 }
 
-impl Into<i64> for ErrorCode {
-    fn into(self) -> i64 {
-        self.code()
+impl From<ErrorCode> for i64 {
+    fn from(code: ErrorCode) -> Self {
+        code.code()
     }
 }
 

--- a/src/jsonrpc/error.rs
+++ b/src/jsonrpc/error.rs
@@ -181,6 +181,18 @@ impl Display for Error {
 
 impl std::error::Error for Error {}
 
+/// Error response returned for every request received before the server is initialized.
+///
+/// See [here](https://microsoft.github.io/language-server-protocol/specification#initialize)
+/// for reference.
+pub(crate) const fn not_initialized_error() -> Error {
+    Error {
+        code: ErrorCode::ServerError(-32002),
+        message: Cow::Borrowed("Server not initialized"),
+        data: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/jsonrpc/request.rs
+++ b/src/jsonrpc/request.rs
@@ -1,0 +1,163 @@
+use std::borrow::Cow;
+use std::fmt::{self, Display, Formatter};
+
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+
+use super::{Id, Version};
+
+fn deserialize_some<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    T::deserialize(deserializer).map(Some)
+}
+
+/// A JSON-RPC request or notification.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct Request {
+    jsonrpc: Version,
+    #[serde(default)]
+    method: Cow<'static, str>,
+    #[serde(default, deserialize_with = "deserialize_some")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    params: Option<Value>,
+    #[serde(default, deserialize_with = "deserialize_some")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<Id>,
+}
+
+impl Request {
+    /// Starts building a JSON-RPC method call.
+    ///
+    /// Returns a `RequestBuilder`, which allows setting the `params` field or adding a request ID.
+    pub fn build<M>(method: M) -> RequestBuilder
+    where
+        M: Into<Cow<'static, str>>,
+    {
+        RequestBuilder {
+            method: method.into(),
+            params: None,
+            id: None,
+        }
+    }
+
+    /// Constructs a JSON-RPC request from its corresponding LSP type.
+    pub(crate) fn from_request<R>(id: Id, params: R::Params) -> Self
+    where
+        R: lsp_types::request::Request,
+    {
+        // Since `R::Params` come from the `lsp-types` crate and validity is enforced via the
+        // `Request` trait, the `unwrap()` call below should never fail.
+        Request {
+            jsonrpc: Version,
+            method: R::METHOD.into(),
+            params: Some(serde_json::to_value(params).unwrap()),
+            id: Some(id),
+        }
+    }
+
+    /// Constructs a JSON-RPC notification from its corresponding LSP type.
+    pub(crate) fn from_notification<N>(params: N::Params) -> Self
+    where
+        N: lsp_types::notification::Notification,
+    {
+        // Since `N::Params` comes from the `lsp-types` crate and validity is enforced via the
+        // `Notification` trait, the `unwrap()` call below should never fail.
+        Request {
+            jsonrpc: Version,
+            method: N::METHOD.into(),
+            params: Some(serde_json::to_value(params).unwrap()),
+            id: None,
+        }
+    }
+
+    /// Returns the name of the method to be invoked.
+    pub fn method(&self) -> &str {
+        self.method.as_ref()
+    }
+
+    /// Returns the unique ID of this request, if present.
+    pub fn id(&self) -> Option<&Id> {
+        self.id.as_ref()
+    }
+
+    /// Returns the `params` field, if present.
+    pub fn params(&self) -> Option<&Value> {
+        self.params.as_ref()
+    }
+
+    /// Splits this request into the method name, request ID, and the `params` field, if present.
+    pub fn into_parts(self) -> (Cow<'static, str>, Option<Id>, Option<Value>) {
+        (self.method, self.id, self.params)
+    }
+}
+
+impl Display for Request {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        use std::{io, str};
+
+        struct WriterFormatter<'a, 'b: 'a> {
+            inner: &'a mut Formatter<'b>,
+        }
+
+        impl<'a, 'b> io::Write for WriterFormatter<'a, 'b> {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                fn io_error<E>(_: E) -> io::Error {
+                    // Error value does not matter because fmt::Display impl below just
+                    // maps it to fmt::Error
+                    io::Error::new(io::ErrorKind::Other, "fmt error")
+                }
+                let s = str::from_utf8(buf).map_err(io_error)?;
+                self.inner.write_str(s).map_err(io_error)?;
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut w = WriterFormatter { inner: f };
+        serde_json::to_writer(&mut w, self).map_err(|_| fmt::Error)
+    }
+}
+
+/// A builder to construct the properties of a `Request`.
+///
+/// To construct a `RequestBuilder`, refer to [`Request::build`].
+#[derive(Debug)]
+pub struct RequestBuilder {
+    method: Cow<'static, str>,
+    params: Option<Value>,
+    id: Option<Id>,
+}
+
+impl RequestBuilder {
+    /// Sets the `id` member of the request to the given value.
+    ///
+    /// If this method is not called, the resulting `Request` will be assumed to be a notification.
+    pub fn id<I: Into<Id>>(mut self, id: I) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    /// Sets the `params` member of the request to the given value.
+    ///
+    /// This member is omitted from the request by default.
+    pub fn params<V: Into<Value>>(mut self, params: V) -> Self {
+        self.params = Some(params.into());
+        self
+    }
+
+    /// Constructs the JSON-RPC request and returns it.
+    pub fn finish(self) -> Request {
+        Request {
+            jsonrpc: Version,
+            method: self.method,
+            params: self.params,
+            id: self.id,
+        }
+    }
+}

--- a/src/jsonrpc/request.rs
+++ b/src/jsonrpc/request.rs
@@ -45,12 +45,16 @@ impl Request {
     }
 
     /// Constructs a JSON-RPC request from its corresponding LSP type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `params` could not be serialized into a [`serde_json::Value`]. Since the
+    /// [`lsp_types::request::Request`] trait promises this invariant is upheld, this should never
+    /// happen in practice (unless the trait was implemented incorrectly).
     pub(crate) fn from_request<R>(id: Id, params: R::Params) -> Self
     where
         R: lsp_types::request::Request,
     {
-        // Since `R::Params` come from the `lsp-types` crate and validity is enforced via the
-        // `Request` trait, the `unwrap()` call below should never fail.
         Request {
             jsonrpc: Version,
             method: R::METHOD.into(),
@@ -60,12 +64,16 @@ impl Request {
     }
 
     /// Constructs a JSON-RPC notification from its corresponding LSP type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `params` could not be serialized into a [`serde_json::Value`]. Since the
+    /// [`lsp_types::notification::Notification`] trait promises this invariant is upheld, this
+    /// should never happen in practice (unless the trait was implemented incorrectly).
     pub(crate) fn from_notification<N>(params: N::Params) -> Self
     where
         N: lsp_types::notification::Notification,
     {
-        // Since `N::Params` comes from the `lsp-types` crate and validity is enforced via the
-        // `Notification` trait, the `unwrap()` call below should never fail.
         Request {
             jsonrpc: Version,
             method: N::METHOD.into(),

--- a/src/jsonrpc/request.rs
+++ b/src/jsonrpc/request.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::fmt::{self, Display, Formatter};
+use std::str::FromStr;
 
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
@@ -121,6 +122,14 @@ impl Display for Request {
 
         let mut w = WriterFormatter { inner: f };
         serde_json::to_writer(&mut w, self).map_err(|_| fmt::Error)
+    }
+}
+
+impl FromStr for Request {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
     }
 }
 

--- a/src/jsonrpc/response.rs
+++ b/src/jsonrpc/response.rs
@@ -1,0 +1,108 @@
+use std::fmt::{self, Debug, Formatter};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::{Error, Id, Result, Version};
+
+#[derive(Clone, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+enum Kind {
+    Ok { result: Value },
+    Err { error: Error },
+}
+
+/// A successful or failed JSON-RPC response.
+#[derive(Clone, PartialEq, Deserialize, Serialize)]
+pub struct Response {
+    jsonrpc: Version,
+    #[serde(flatten)]
+    kind: Kind,
+    id: Id,
+}
+
+impl Response {
+    /// Creates a new successful response from a request ID and `Error` object.
+    pub const fn from_ok(id: Id, result: Value) -> Self {
+        Response {
+            jsonrpc: Version,
+            kind: Kind::Ok { result },
+            id,
+        }
+    }
+
+    /// Creates a new error response from a request ID and `Error` object.
+    pub const fn from_error(id: Id, error: Error) -> Self {
+        Response {
+            jsonrpc: Version,
+            kind: Kind::Err { error },
+            id,
+        }
+    }
+
+    /// Creates a new response from a request ID and either an `Ok(Value)` or `Err(Error)` body.
+    pub fn from_parts(id: Id, body: Result<Value>) -> Self {
+        match body {
+            Ok(result) => Response::from_ok(id, result),
+            Err(error) => Response::from_error(id, error),
+        }
+    }
+
+    /// Splits the response into a request ID paired with either an `Ok(Value)` or `Err(Error)` to
+    /// signify whether the response is a success or failure.
+    pub fn into_parts(self) -> (Id, Result<Value>) {
+        match self.kind {
+            Kind::Ok { result } => (self.id, Ok(result)),
+            Kind::Err { error } => (self.id, Err(error)),
+        }
+    }
+
+    /// Returns `true` if the response indicates success.
+    pub const fn is_ok(&self) -> bool {
+        matches!(self.kind, Kind::Ok { .. })
+    }
+
+    /// Returns `true` if the response indicates failure.
+    pub const fn is_error(&self) -> bool {
+        !self.is_ok()
+    }
+
+    /// Returns the `result` value, if it exists.
+    ///
+    /// This member only exists if the response indicates success.
+    pub const fn result(&self) -> Option<&Value> {
+        match &self.kind {
+            Kind::Ok { result } => Some(result),
+            _ => None,
+        }
+    }
+
+    /// Returns the `error` value, if it exists.
+    ///
+    /// This member only exists if the response indicates failure.
+    pub const fn error(&self) -> Option<&Error> {
+        match &self.kind {
+            Kind::Err { error } => Some(error),
+            _ => None,
+        }
+    }
+
+    /// Returns the corresponding request ID, if known.
+    pub const fn id(&self) -> &Id {
+        &self.id
+    }
+}
+
+impl Debug for Response {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let mut d = f.debug_struct("Response");
+        d.field("jsonrpc", &self.jsonrpc);
+
+        match &self.kind {
+            Kind::Ok { result } => d.field("result", result),
+            Kind::Err { error } => d.field("error", error),
+        };
+
+        d.field("id", &self.id).finish()
+    }
+}

--- a/src/jsonrpc/response.rs
+++ b/src/jsonrpc/response.rs
@@ -1,4 +1,5 @@
 use std::fmt::{self, Debug, Formatter};
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -104,5 +105,13 @@ impl Debug for Response {
         };
 
         d.field("id", &self.id).finish()
+    }
+}
+
+impl FromStr for Response {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        serde_json::from_str(s)
     }
 }


### PR DESCRIPTION
### Added

* Implement `std::str::FromStr` for `Request` and `Response`.
* Implement `From<jsonrpc::ErrorCode>` for `i64`.

### Changed

* Avoid heap allocation in `Version` deserialization.
* Make `Version` a private struct instead of `pub(crate)`.
* Un-derive `Copy` for `Version` because it's unnecessary.
* Group `jsonrpc::Result<T>`and `not_initialized_error()` with all the error stuff, re-export it to parent module for public access
* Replace custom `Serialize`/`Deserialize` implementations for `ErrorCode` with `#[serde(into/from)]`.
* Move `Request`/`RequestBuilder` to `src/jsonrpc/request.rs` submodule.
* Move `Response` to `src/jsonrpc/response.rs` submodule.
* Better document panic behavior for `lsp-types` conversions as `Request::from_{notification,request}` doc comments.

This pull request contains a grab-bag of miscellaneous improvements to the `jsonrpc` module that should improve deserialization performance slightly, but mostly make the code easier to read, grok, and maintain.

It was also supposed to include some major improvements to deserializing request `params` and `id`s, and handling invalid JSON-RPC messages in the `Message` type (see commits in the full [`improve-jsonrpc-deserialization`](https://github.com/ebkalderon/tower-lsp/tree/improve-jsonrpc-deserialization) branch), but I ran into an inconsistency in the official LSP spec and chose to not pursue this for now. I've asked for clarification in https://github.com/microsoft/language-server-protocol/issues/1686, filed earlier today.