### PR TITLE
Implement pull-based diagnostic requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bytes = "1.0"
 dashmap = "5.1"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 httparse = "1.8"
-lsp-types = "0.94"
+lsp-types = "0.94.1"
 memchr = "2.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ features = ["runtime-agnostic"]
 ## Using proposed features
 
 You can use enable proposed features in the
-[LSP Specification version 3.17](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/)
+[LSP Specification version 3.18](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/)
 by enabling the `proposed` Cargo crate feature. Note that there are no semver
 guarantees to the `proposed` features so there may be breaking changes between
 any type of version in the `proposed` features.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -841,7 +841,67 @@ pub trait LanguageServer: Send + Sync + 'static {
         Err(Error::method_not_found())
     }
 
-    // TODO: Add `diagnostic()` and `workspace_diagnostic()` here when supported by `lsp-types`.
+    /// The [`textDocument/diagnostic`] request is sent from the client to the server to ask the
+    /// server to compute the diagnostics for a given document.
+    ///
+    /// As with other pull requests, the server is asked to compute the diagnostics for the
+    /// currently synced version of the document.
+    ///
+    /// The request doesn't define its own client and server capabilities. It is only issued if a
+    /// server registers for the [`textDocument/diagnostic`] request.
+    ///
+    /// [`textDocument/diagnostic`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_diagnostic
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.17.0.
+    #[rpc(name = "textDocument/diagnostic")]
+    async fn diagnostic(
+        &self,
+        params: DocumentDiagnosticParams,
+    ) -> Result<DocumentDiagnosticReportResult> {
+        let _ = params;
+        error!("Got a textDocument/diagnostic request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
+
+    /// The [`workspace/diagnostic`] request is sent from the client to the server to ask the
+    /// server to compute workspace wide diagnostics which previously where pushed from the server
+    /// to the client.
+    ///
+    /// In contrast to the [`textDocument/diagnostic`] request, the workspace request can be
+    /// long-running and is not bound to a specific workspace or document state. If the client
+    /// supports streaming for the workspace diagnostic pull, it is legal to provide a
+    /// `textDocument/diagnostic` report multiple times for the same document URI. The last one
+    /// reported will win over previous reports.
+    ///
+    /// [`textDocument/diagnostic`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_diagnostic
+    ///
+    /// If a client receives a diagnostic report for a document in a workspace diagnostic request
+    /// for which the client also issues individual document diagnostic pull requests, the client
+    /// needs to decide which diagnostics win and should be presented. In general:
+    ///
+    /// * Diagnostics for a higher document version should win over those from a lower document
+    ///   version (e.g. note that document versions are steadily increasing).
+    /// * Diagnostics from a document pull should win over diagnostics from a workspace pull.
+    ///
+    /// The request doesn't define its own client and server capabilities. It is only issued if a
+    /// server registers for the [`workspace/diagnostic`] request.
+    ///
+    /// [`workspace/diagnostic`]: https://microsoft.github.io/language-server-protocol/specification#workspace_diagnostic
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.17.0.
+    #[rpc(name = "workspace/diagnostic")]
+    async fn workspace_diagnostic(
+        &self,
+        params: WorkspaceDiagnosticParams,
+    ) -> Result<WorkspaceDiagnosticReportResult> {
+        let _ = params;
+        error!("Got a workspace/diagnostic request, but it is not implemented");
+        Err(Error::method_not_found())
+    }
 
     /// The [`textDocument/signatureHelp`] request is sent from the client to the server to request
     /// signature information at a given cursor position.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -817,7 +817,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// # Compatibility
     ///
     /// Since 3.16.0, the client can signal that it can resolve more properties lazily. This is
-    /// done using the completion_item.resolve_support` client capability which lists all
+    /// done using the `completion_item.resolve_support` client capability which lists all
     /// properties that can be filled in during a `completionItem/resolve` request.
     ///
     /// All other properties (usually `sort_text`, `filter_text`, `insert_text`, and `text_edit`)

--- a/src/service/client.rs
+++ b/src/service/client.rs
@@ -315,7 +315,28 @@ impl Client {
         self.send_request::<InlayHintRefreshRequest>(()).await
     }
 
-    // TODO: Add `workspace_diagnostic_refresh()` here when supported by `lsp-types`.
+    /// Asks the client to refresh all needed document and workspace diagnostics.
+    ///
+    /// This is useful if a server detects a project wide configuration change which requires a
+    /// re-calculation of all diagnostics.
+    ///
+    /// This corresponds to the [`workspace/diagnostic/refresh`] request.
+    ///
+    /// [`workspace/diagnostic/refresh`]: https://microsoft.github.io/language-server-protocol/specification#diagnostic_refresh
+    ///
+    /// # Initialization
+    ///
+    /// If the request is sent to the client before the server has been initialized, this will
+    /// immediately return `Err` with JSON-RPC error code `-32002` ([read more]).
+    ///
+    /// [read more]: https://microsoft.github.io/language-server-protocol/specification#initialize
+    ///
+    /// # Compatibility
+    ///
+    /// This request was introduced in specification version 3.17.0.
+    pub async fn workspace_diagnostic_refresh(&self) -> jsonrpc::Result<()> {
+        self.send_request::<WorkspaceDiagnosticRefresh>(()).await
+    }
 
     /// Submits validation diagnostics for an open file with the given URI.
     ///


### PR DESCRIPTION
### Added

* Implement `textDocument/diagnostic` server request.
* Implement `workspace/diagnostic` server request.
* Implement `workspace/diagnostic/refresh` client request.

### Changed

* Update to `lsp-types` 0.94.1.

### Fixed

* Fix broken Markdown in doc comment for `LanguageServer::completion()` method.
* Update "proposed features" section in `README.md`.

This pull request upgrades our `lsp-types` version in response to https://github.com/gluon-lang/lsp-types/pull/258 finally getting merged upstream. It also brings `tower-lsp` up to full compliance with LSP version 3.17.0, at last. :tada: 

Closes #374.