### PR TITLE
Prepare release 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.20.0] - 2023-08-10
+
+### Added
+
+* Add support for pull-based diagnostics from LSP 3.17.0 (PR #396).
+  * Implement `textDocument/diagnostic` server request.
+  * Implement `workspace/diagnostic` server request.
+  * Implement `workspace/diagnostic/refresh` client request.
+* Implement `std::str::FromStr` for `jsonrpc::{Request,Response}` (PR #379).
+* Implement `From<jsonrpc::ErrorCode>` for `i64` (PR #379).
+* Document supported LSP features in [FEATURES.md](./FEATURES.md) matrix (PR
+  #383).
+
+### Changed
+
+* Bump minimum supported Rust version from `1.52.0` to `1.64.0` (PR #377, PR #395).
+* Update `lsp-types` from `0.94` to `0.94.1` (PR #396).
+* Update `syn` from `1` to `2` (PR #390).
+* Update dev-dependency `async-tungstenite` from `0.18` to `0.22` (PR #395).
+* Update dev-dependency `ws_stream_tungstenite` from `0.9` to `0.10` (PR #395).
+* Optimize JSON-RPC deserialization types.
+  * Change `jsonrpc::Error::message` field to `Cow<'static, str>` (PR #378).
+  * Mark several methods on `jsonrpc::Error` as `const fn` (PR #378).
+  * Mark all methods on `jsonrpc::ErrorCode` as `const fn` (PR #378).
+  * Avoid heap allocation in `version` field deserialization (PR #379).
+
+### Fixed
+
+* Fix broken Markdown in doc comment for `LanguageServer::completion()` (PR #396).
+
 ## [0.19.0] - 2023-02-28
 
 ### Added
@@ -549,7 +579,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * `textDocument/hover`
   * `textDocument/documentHighlight`
 
-[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.19.0...HEAD
+[Unreleased]: https://github.com/ebkalderon/tower-lsp/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/ebkalderon/tower-lsp/compare/v0.16.0...v0.17.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 edition = "2021"
 rust-version = "1.64.0"
@@ -34,7 +34,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.17", optional = true }
 tokio-util = { version = "0.7", optional = true, features = ["codec"] }
-tower-lsp-macros = { version = "0.8", path = "./tower-lsp-macros" }
+tower-lsp-macros = { version = "0.9", path = "./tower-lsp-macros" }
 tower = { version = "0.4", default-features = false, features = ["util"] }
 tracing = "0.1"
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -35,11 +35,11 @@ Symbol          | Description
 
 </details>
 
-### Overall status: (77.5/90) _~86.1%_
+### Overall status: (80.5/90) _~89.4%_
 
 ## [3.17.0] - 2022-05-10
 
-### Status: (9/16)
+### Status: (12/16)
 
 Method Name                           | Message Type                | Supported      | Tracking Issue(s)
 --------------------------------------|:---------------------------:|:--------------:|------------------
@@ -55,9 +55,9 @@ Method Name                           | Message Type                | Supported 
 [`workspace/inlayHint/refresh`]       | :arrow_right_hook:          | :green_circle: | ~[#352]~
 [`textDocument/inlineValue`]          | :leftwards_arrow_with_hook: | :green_circle: | ~[#352]~
 [`workspace/inlineValue/refresh`]     | :arrow_right_hook:          | :green_circle: | ~[#352]~
-[`textDocument/diagnostic`]           | :leftwards_arrow_with_hook: | :red_circle:   | [#374]
-[`workspace/diagnostic`]              | :leftwards_arrow_with_hook: | :red_circle:   | [#374]
-[`workspace/diagnostic/refresh`]      | :arrow_right_hook:          | :red_circle:   | [#374]
+[`textDocument/diagnostic`]           | :leftwards_arrow_with_hook: | :green_circle: | ~[#374]~
+[`workspace/diagnostic`]              | :leftwards_arrow_with_hook: | :green_circle: | ~[#374]~
+[`workspace/diagnostic/refresh`]      | :arrow_right_hook:          | :green_circle: | ~[#374]~
 [`workspaceSymbol/resolve`]           | :leftwards_arrow_with_hook: | :green_circle: |
 
 [`notebookDocument/didOpen`]: https://microsoft.github.io/language-server-protocol/specification#notebookDocument_didOpen
@@ -74,7 +74,7 @@ Method Name                           | Message Type                | Supported 
 [`workspace/inlineValue/refresh`]: https://microsoft.github.io/language-server-protocol/specification#workspace_inlineValue_refresh
 [`textDocument/diagnostic`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_diagnostic
 [`workspace/diagnostic`]: https://microsoft.github.io/language-server-protocol/specification#workspace_diagnostic
-[`workspace/diagnostic/refresh`]: https://microsoft.github.io/language-server-protocol/specification#workspace_diagnostic_refresh
+[`workspace/diagnostic/refresh`]: https://microsoft.github.io/language-server-protocol/specification#diagnostic_refresh
 [`workspaceSymbol/resolve`]: https://microsoft.github.io/language-server-protocol/specification#workspace_symbolResolve
 
 [#352]: https://github.com/ebkalderon/tower-lsp/issues/352

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2022 Eyal Kalderon
+Copyright (c) 2023 Eyal Kalderon
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tower-lsp-macros/Cargo.toml
+++ b/tower-lsp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-lsp-macros"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Internal procedural macros for tower-lsp"
 edition = "2021"


### PR DESCRIPTION
### Changed

* Bump `tower-lsp` version to 0.20.0.
* Bump `tower-lsp-macros` version to 0.9.0.
* Update `FEATURES.md` to reflect the recent merge of #396.
* Update `CHANGELOG.md`.

### Fixed

* Update copyright year in `LICENSE-MIT`.

This release should finally resolve #374 when published. It's about time! :relieved: 