### PR TITLE
Add re-export for `serde_json::Value`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,13 +94,15 @@ use lsp_types::request::{
     GotoImplementationResponse, GotoTypeDefinitionParams, GotoTypeDefinitionResponse,
 };
 use lsp_types::*;
-use serde_json::Value;
 use tower_lsp_macros::rpc;
 use tracing::{error, warn};
 
 use self::jsonrpc::{Error, Result};
 
 pub mod jsonrpc;
+pub mod serde_json {
+    pub use serde_json::Value;
+}
 
 mod codec;
 mod service;


### PR DESCRIPTION
Closes #404 

This PR resolves #404 by adding a re-export of just `serde_json::Value`. I have not come across any other types from `serde_json` that would be useful to have re-exported yet but there may be others!