### PR TITLE
chore: missed `WorkspaceDiagnosticRefresh`

### DIFF
--- a/src/service/client.rs
+++ b/src/service/client.rs
@@ -10,6 +10,7 @@ use std::task::{Context, Poll};
 use futures::channel::mpsc::{self, Sender};
 use futures::future::BoxFuture;
 use futures::sink::SinkExt;
+use lsp_types::request::WorkspaceDiagnosticRefresh;
 use lsp_types::*;
 use serde::Serialize;
 use serde_json::Value;

--- a/src/service/client/pending.rs
+++ b/src/service/client/pending.rs
@@ -64,6 +64,7 @@ impl Pending {
 impl Debug for Pending {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         #[derive(Debug)]
+        #[allow(unused)]
         struct Waiters(usize);
 
         let iter = self


### PR DESCRIPTION
I found that I cannot compiled this crate, so I wanner to fix it