### PR TITLE
Actually exit after receiving `exit` notification

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -55,7 +55,7 @@ impl Display for ExitedError {
 #[derive(Debug)]
 pub struct LspService<S> {
     inner: Router<S, ExitedError>,
-    state: Arc<ServerState>,
+    pub(crate) state: Arc<ServerState>,
 }
 
 impl<S: LanguageServer> LspService<S> {


### PR DESCRIPTION
This fixes https://github.com/ebkalderon/tower-lsp/issues/399 and https://github.com/ebkalderon/tower-lsp/issues/424.

Note: this will not compile until https://github.com/ebkalderon/tower-lsp/pull/406/ is merged.